### PR TITLE
fix curtain tear

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -47,7 +47,7 @@ result engine::init()
 	l->info("Engine init begin");
 	rosy_packager::asset a{};
 	{
-		a.asset_path = "..\\assets\\deccer_cubes\\SM_Deccer_Cubes_Textured_Complex.rsy";
+		a.asset_path = "..\\assets\\sponza\\sponza.rsy";
 		{
 			if (const auto res = a.read(); res != result::ok)
 			{

--- a/src/Engine/Types.h
+++ b/src/Engine/Types.h
@@ -18,6 +18,7 @@ namespace rosy
 		write_failed,
 		read_failed,
 		create_failed,
+		update_failed,
 		overflow,
 	};
 


### PR DESCRIPTION
This issue fixes a bug where updating the scene data without a barrier caused a visible tear in the geometry when moving the camera. The camera now is now updated via vkCmdUpdateBuffer before a memory barrier after recording begins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated asset loading to use a different scene (Sponza)
	- Enhanced scene data update mechanism for rendering
	- Added new error handling for update operations

- **Bug Fixes**
	- Improved buffer usage flags for more flexible scene data transfer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->