### PR TITLE
Fix object space

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,5 +1,5 @@
-# Visual Studio generated .editorconfig file with C++ settings.
 root = true
+# Visual Studio generated .editorconfig file with C++ settings.
 
 [*]
 end_of_line = lf
@@ -10,12 +10,15 @@ trim_trailing_whitespace = true
 charset = utf-8
 max_line_length = 180
 
+# ReSharper properties
+resharper_cpp_max_line_length = 210
+
 # Ignore paths
 [/libs/**]
-charset = unset
-end_of_line = unset
-insert_final_newline = unset
-trim_trailing_whitespace = unset
-indent_style = unset
-indent_size = unset
-max_line_length = unset
+charset = 
+end_of_line = 
+insert_final_newline = 
+trim_trailing_whitespace = 
+indent_style = 
+indent_size = 
+max_line_length = 

--- a/src/Engine/DebugUI.cpp
+++ b/src/Engine/DebugUI.cpp
@@ -236,7 +236,7 @@ void debug_ui::graphics_debug_ui(const engine_stats& eng_stats, const graphics_s
                 ImGui::TableNextColumn();
                 ImGui::Checkbox("Enable Shadows", &wls->fragment_config.shadows_enabled);
                 ImGui::TableNextColumn();
-                ImGui::Text("");
+                ImGui::Checkbox("Enable Normal maps", &wls->fragment_config.normal_maps_enabled);
 
                 ImGui::EndTable();
             }

--- a/src/Engine/DebugUI.cpp
+++ b/src/Engine/DebugUI.cpp
@@ -198,6 +198,12 @@ void debug_ui::graphics_debug_ui(const engine_stats& eng_stats, const graphics_s
                 ImGui::TableNextColumn();
                 ImGui::Checkbox("Flip tangent w", &wls->light.flip_tangent_w);
 
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Checkbox("Inverse BNT", &wls->light.inverse_bnt);
+                ImGui::TableNextColumn();
+                ImGui::Text("");
+
                 ImGui::EndTable();
             }
         }

--- a/src/Engine/DebugUI.cpp
+++ b/src/Engine/DebugUI.cpp
@@ -156,7 +156,7 @@ void debug_ui::graphics_debug_ui(const engine_stats& eng_stats, const graphics_s
 
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();
-                ImGui::ColorEdit4("Ambient light", wls->light.sunlight_color.data(), 0);
+                ImGui::ColorEdit4("Sunlight color", wls->light.sunlight_color.data(), 0);
 
                 ImGui::EndTable();
             }

--- a/src/Engine/DebugUI.cpp
+++ b/src/Engine/DebugUI.cpp
@@ -120,27 +120,47 @@ void debug_ui::graphics_debug_ui(const engine_stats& eng_stats, const graphics_s
         }
         if (ImGui::CollapsingHeader("Lighting"))
         {
-            if (ImGui::BeginTable("Edit Scene Data", 1,
-                                  ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders))
+            if (ImGui::BeginTable("Edit Scene Data", 1, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders))
             {
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();
                 ImGui::SliderFloat("Spherical distance", &wls->light_debug.sun_distance, 0.f, 25.f);
-                ImGui::SliderFloat("Spherical pitch", &wls->light_debug.sun_pitch, 0.f,
-                                   4 * static_cast<float>(pi));
-                ImGui::SliderFloat("Spherical yaw", &wls->light_debug.sun_yaw, 0.f,
-                                   4 * static_cast<float>(pi));
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::SliderFloat("Spherical pitch", &wls->light_debug.sun_pitch, 0.f, 4 * static_cast<float>(pi));
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::SliderFloat("Spherical yaw", &wls->light_debug.sun_yaw, 0.f, 4 * static_cast<float>(pi));
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
                 ImGui::SliderFloat("Light depth", &wls->light_debug.orthographic_depth, 0.f, 500.f);
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
                 ImGui::SliderFloat("Light cascade level", &wls->light_debug.cascade_level, 0.f, 50.f);
-                ImGui::SliderFloat("Depth bias constant", &wls->light.depth_bias_constant, -500.f,
-                                   500.f);
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::SliderFloat("Depth bias constant", &wls->light.depth_bias_constant, -500.f, 500.f);
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
                 ImGui::SliderFloat("Depth bias clamp", &wls->light.depth_bias_clamp, -500.f, 500.f);
-                ImGui::SliderFloat("Depth bias slope factor", &wls->light.depth_bias_slope_factor,
-                                   -50.f, 50.f);
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::SliderFloat("Ambient light", &wls->light.ambient_light, 0.f, 1.f);
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::ColorEdit4("Ambient light", wls->light.sunlight_color.data(), 0);
+
                 ImGui::EndTable();
             }
-            if (ImGui::BeginTable("##ToggleOptions", 2,
-                                  ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders))
+            if (ImGui::BeginTable("##ToggleOptions", 2, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders))
             {
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();
@@ -214,7 +234,7 @@ void debug_ui::graphics_debug_ui(const engine_stats& eng_stats, const graphics_s
         }
         if (ImGui::CollapsingHeader("Fragment Config"))
         {
-            ImGui::RadioButton("color", &wls->fragment_config.output, 0);
+            ImGui::RadioButton("default", &wls->fragment_config.output, 0);
             ImGui::SameLine();
             ImGui::RadioButton("normal", &wls->fragment_config.output, 1);
             ImGui::SameLine();
@@ -223,6 +243,8 @@ void debug_ui::graphics_debug_ui(const engine_stats& eng_stats, const graphics_s
             ImGui::RadioButton("light", &wls->fragment_config.output, 3);
             ImGui::SameLine();
             ImGui::RadioButton("view", &wls->fragment_config.output, 4);
+            ImGui::SameLine();
+            ImGui::RadioButton("vertex colors", &wls->fragment_config.output, 5);
             if (ImGui::BeginTable("##ToggleFragmentOptions", 2,
                                   ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders))
             {

--- a/src/Engine/Editor.cpp
+++ b/src/Engine/Editor.cpp
@@ -603,6 +603,7 @@ namespace
                                         new_destination_node.world_scale = md.scale;
                                         new_destination_node.world_yaw = md.yaw;
                                     }
+                                    new_destination_node.coordinate_system = a->asset_coordinate_system;
                                     new_destination_node.transform = source_node.transform;
                                     new_destination_node.child_nodes = source_node.child_nodes; // These are remapped below.
                                     new_destination_node.mesh_id = UINT32_MAX; // This is remapped below.

--- a/src/Engine/Editor.cpp
+++ b/src/Engine/Editor.cpp
@@ -543,7 +543,7 @@ namespace
                             }
                             node_descendants.push(static_cast<uint32_t>(node_index));
                         }
-                        bool first_node{true};
+                        bool is_world_node{true};
                         while (!node_descendants.empty())
                         {
                             uint32_t current_node_index = node_descendants.front();
@@ -559,7 +559,7 @@ namespace
                                     if (nm.source_index == current_node_index)
                                     {
                                         node_mapped = true;
-                                        if (first_node)
+                                        if (is_world_node)
                                         {
                                             // Even in this case we have seen the node before, add the top level model node to static or mob
                                             // the same model can be added multiple times.
@@ -597,26 +597,27 @@ namespace
                                     rosy_packager::node source_node = a->nodes[current_node_index];
                                     rosy_packager::node new_destination_node{};
                                     new_destination_node.name = source_node.name;
-                                    if (first_node) {
-                                        // Set these only for the initial node.
+                                    {
+                                        // Every node needs to know its world node's parent's world transform
                                         new_destination_node.world_translate = md.location;
                                         new_destination_node.world_scale = md.scale;
                                         new_destination_node.world_yaw = md.yaw;
                                     }
                                     new_destination_node.coordinate_system = a->asset_coordinate_system;
+                                    new_destination_node.is_world_node = is_world_node;
                                     new_destination_node.transform = source_node.transform;
                                     new_destination_node.child_nodes = source_node.child_nodes; // These are remapped below.
                                     new_destination_node.mesh_id = UINT32_MAX; // This is remapped below.
                                     level_asset.nodes.push_back(new_destination_node);
                                 }
                             }
-                            if (first_node)
+                            if (is_world_node)
                             {
-                                // Add the top level model node to static or mob.
+                                // Add the top level world model node to static or mob.
                                 switch (static_cast<editor_command::model_type>(md.model_type))
                                 {
                                 case editor_command::model_type::no_model:
-                                    l->error(std::format("invalid model type for {}", md.id));
+                                    l->error(std::format("invalid world model type for {}", md.id));
                                     return result::error;
                                 case editor_command::model_type::mob_model:
                                     level_asset.nodes[1].child_nodes.push_back(destination_node_index);
@@ -625,7 +626,7 @@ namespace
                                     level_asset.nodes[2].child_nodes.push_back(destination_node_index);
                                     break;
                                 }
-                                first_node = false;
+                                is_world_node = false;
                             }
                             // Get a reference to the destination node to change mesh index. Children have to be fully re-indexed in this queue before they can be remapped.
                             {
@@ -868,7 +869,7 @@ namespace
                                 }
                             }
                             for (const uint32_t child : a->nodes[current_node_index].child_nodes) node_descendants.push(child);
-                            first_node = false;
+                            is_world_node = false;
                         }
                     }
                 }

--- a/src/Engine/Editor.cpp
+++ b/src/Engine/Editor.cpp
@@ -919,10 +919,9 @@ namespace
 
         result load_asset([[maybe_unused]] level_editor_state* state)
         {
-            std::array<std::string, 6> asset_paths{
+            std::array<std::string, 5> asset_paths{
                 R"(..\assets\houdini\exports\Box_002\Box_002.rsy)",
                 R"(..\assets\sponza\sponza.rsy)",
-                R"(..\assets\rosy_tt\rosy_tt1.rsy)",
                 R"(..\assets\cornell_dragons\cornell_dragons.rsy)",
                 R"(..\assets\two_cubes\two_cubes.rsy)",
                 R"(..\assets\deccer_cubes\SM_Deccer_Cubes_Textured_Complex.rsy)",

--- a/src/Engine/Editor.cpp
+++ b/src/Engine/Editor.cpp
@@ -599,9 +599,9 @@ namespace
                                     new_destination_node.name = source_node.name;
                                     if (first_node) {
                                         // Set these only for the initial node.
-                                        new_destination_node.custom_translate = md.location;
-                                        new_destination_node.custom_uniform_scale = md.scale;
-                                        new_destination_node.custom_yaw = md.yaw;
+                                        new_destination_node.world_translate = md.location;
+                                        new_destination_node.world_scale = md.scale;
+                                        new_destination_node.world_yaw = md.yaw;
                                     }
                                     new_destination_node.transform = source_node.transform;
                                     new_destination_node.child_nodes = source_node.child_nodes; // These are remapped below.

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -352,6 +352,8 @@ namespace
         uint32_t color_sampler_index{UINT32_MAX};
         uint32_t normal_sampled_image_index{UINT32_MAX};
         uint32_t normal_sampler_index{UINT32_MAX};
+        uint32_t metallic_sampled_image_index{ UINT32_MAX };
+        uint32_t metallic_sampler_index{ UINT32_MAX };
     };
 
     struct gpu_material_buffer
@@ -4087,11 +4089,24 @@ namespace
                     {
                         normal_image_sampler_index = color_image_sampler_desc_index[m.normal_image_index];
 
-                        assert(dds_textures.size() > m.color_image_index);
+                        assert(dds_textures.size() > m.normal_image_index);
 
                         if (m.normal_sampler_index < sampler_desc_index.size())
                         {
                             normal_sampler_index = sampler_desc_index[m.normal_sampler_index];
+                        }
+                    }
+                    uint32_t metallic_image_sampler_index = UINT32_MAX;
+                    uint32_t metallic_sampler_index = default_sampler_index;
+                    if (m.metallic_image_index < color_image_sampler_desc_index.size())
+                    {
+                        metallic_image_sampler_index = color_image_sampler_desc_index[m.metallic_image_index];
+
+                        assert(dds_textures.size() > m.metallic_image_index);
+
+                        if (m.metallic_sampler_index < sampler_desc_index.size())
+                        {
+                            metallic_sampler_index = sampler_desc_index[m.metallic_sampler_index];
                         }
                     }
                     gpu_material new_mat{};
@@ -4105,6 +4120,8 @@ namespace
                     new_mat.color_sampler_index = color_sampler_index;
                     new_mat.normal_sampled_image_index = normal_image_sampler_index;
                     new_mat.normal_sampler_index = normal_sampler_index;
+                    new_mat.metallic_sampled_image_index = metallic_image_sampler_index;
+                    new_mat.metallic_sampler_index = metallic_sampler_index;
                     materials.push_back(new_mat);
                 }
 

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -3604,8 +3604,8 @@ namespace
                 dds::Image dds_lib_image;
                 if (const auto res = dds::readFile(input_filename, &dds_lib_image); res != dds::Success)
                 {
-                    l->error(std::format("Failed to read dds lib data for {}", input_filename));
-                    return result::read_failed;
+                    l->warn(std::format("Failed to read dds lib data for {}, is it unused?", input_filename));
+                    continue;
                 }
 
                 VkImageCreateInfo dds_img_create_info = dds::getVulkanImageCreateInfo(&dds_lib_image);
@@ -3634,6 +3634,10 @@ namespace
                     else if (img.image_type == rosy_packager::image_type_normal_map)
                     {
                         new_dds_img.image_format = VK_FORMAT_BC5_UNORM_BLOCK;
+                    }
+                    else if (img.image_type == rosy_packager::image_type_metallic_roughness)
+                    {
+                        new_dds_img.image_format = VK_FORMAT_BC7_SRGB_BLOCK;
                     }
                     else
                     {

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -303,6 +303,7 @@ namespace
         [[maybe_unused]] uint32_t tangent_space_enabled{0};
         [[maybe_unused]] uint32_t shadows_enabled{0};
         [[maybe_unused]] uint32_t normal_maps_enabled{0};
+        [[maybe_unused]] uint32_t inverse_bnt{ 0 };
     };
 
     struct allocated_image
@@ -6002,6 +6003,7 @@ namespace
             const uint32_t flip_tangent_y = new_rls.light.flip_tangent_y ? 1 : 0;
             const uint32_t flip_tangent_z = new_rls.light.flip_tangent_z ? 1 : 0;
             const uint32_t flip_tangent_w = new_rls.light.flip_tangent_w ? 1 : 0;
+            const uint32_t inverse_bnt = new_rls.light.inverse_bnt ? 1 : 0;
             gpu_scene_data sd;
             sd.view = new_rls.cam.v;
             sd.proj = new_rls.cam.p;
@@ -6021,6 +6023,7 @@ namespace
             sd.tangent_space_enabled = tangent_space_enabled;
             sd.shadows_enabled = shadows_enabled;
             sd.normal_maps_enabled = normal_maps_enabled;
+            sd.inverse_bnt = inverse_bnt;
 
             rls = &new_rls;
             scene_data = sd;

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -302,6 +302,7 @@ namespace
         [[maybe_unused]] uint32_t light_enabled{0};
         [[maybe_unused]] uint32_t tangent_space_enabled{0};
         [[maybe_unused]] uint32_t shadows_enabled{0};
+        [[maybe_unused]] uint32_t normal_maps_enabled{0};
     };
 
     struct allocated_image
@@ -352,8 +353,8 @@ namespace
         uint32_t color_sampler_index{UINT32_MAX};
         uint32_t normal_sampled_image_index{UINT32_MAX};
         uint32_t normal_sampler_index{UINT32_MAX};
-        uint32_t metallic_sampled_image_index{ UINT32_MAX };
-        uint32_t metallic_sampler_index{ UINT32_MAX };
+        uint32_t metallic_sampled_image_index{UINT32_MAX};
+        uint32_t metallic_sampler_index{UINT32_MAX};
     };
 
     struct gpu_material_buffer
@@ -3739,12 +3740,12 @@ namespace
                     }
                     if (dds_staging_buffer.info.pMappedData != nullptr)
                     {
-                        size_t offset{ 0 };
+                        size_t offset{0};
                         for (const auto& m : dds_lib_image.mipmaps)
                         {
                             if (offset + m.size() > dds_staging_buffer.info.size)
                             {
-                                l->error(std::format("Error mip mapping buffer overflow. buffer size {}  copy size: {} for {}",  dds_staging_buffer.info.size, offset + m.size(), dds_image_name));
+                                l->error(std::format("Error mip mapping buffer overflow. buffer size {}  copy size: {} for {}", dds_staging_buffer.info.size, offset + m.size(), dds_image_name));
                                 return result::overflow;
                             }
                             memcpy(static_cast<char*>(dds_staging_buffer.info.pMappedData) + offset, static_cast<void*>(m.data()), m.size());
@@ -3819,7 +3820,7 @@ namespace
                         }
                         {
                             std::vector<VkBufferImageCopy> regions;
-                            size_t buffer_offset{ 0 };
+                            size_t buffer_offset{0};
                             VkExtent3D current_extent = new_dds_img.image_extent;
                             for (size_t mip{0}; mip < dds_lib_image.numMips; mip++)
                             {
@@ -5993,6 +5994,7 @@ namespace
             const uint32_t light_enabled = new_rls.fragment_config.light_enabled ? 1 : 0;
             const uint32_t tangent_space_enabled = new_rls.fragment_config.tangent_space_enabled ? 1 : 0;
             const uint32_t shadows_enabled = new_rls.fragment_config.shadows_enabled ? 1 : 0;
+            const uint32_t normal_maps_enabled = new_rls.fragment_config.normal_maps_enabled ? 1 : 0;
             const uint32_t flip_x = new_rls.light.flip_light_x ? 1 : 0;
             const uint32_t flip_y = new_rls.light.flip_light_y ? 1 : 0;
             const uint32_t flip_z = new_rls.light.flip_light_z ? 1 : 0;
@@ -6018,6 +6020,7 @@ namespace
             sd.light_enabled = light_enabled;
             sd.tangent_space_enabled = tangent_space_enabled;
             sd.shadows_enabled = shadows_enabled;
+            sd.normal_maps_enabled = normal_maps_enabled;
 
             rls = &new_rls;
             scene_data = sd;

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -3615,7 +3615,7 @@ namespace
                 num_mip_maps = dds_img_create_info.mipLevels;
 
                 size_t dds_image_data_size{0};
-                for (const auto m : dds_lib_image.mipmaps)
+                for (const auto& m : dds_lib_image.mipmaps)
                 {
                     dds_image_data_size += m.size();
                 }

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -303,7 +303,7 @@ namespace
         [[maybe_unused]] uint32_t tangent_space_enabled{0};
         [[maybe_unused]] uint32_t shadows_enabled{0};
         [[maybe_unused]] uint32_t normal_maps_enabled{0};
-        [[maybe_unused]] uint32_t inverse_bnt{ 0 };
+        [[maybe_unused]] uint32_t inverse_bnt{0};
     };
 
     struct allocated_image
@@ -5106,7 +5106,8 @@ namespace
                             .normal_transform = gou.normal_transform,
                         });
                     }
-                    vkCmdUpdateBuffer(cf.command_buffer,  frame_datas[frame_to_update].graphic_objects_buffer.go_buffer.buffer, sizeof(graphic_object_data) * graphics_object_update_data.offset, sizeof(graphic_object_data) * updated.size(), updated.data());
+                    vkCmdUpdateBuffer(cf.command_buffer, frame_datas[frame_to_update].graphic_objects_buffer.go_buffer.buffer, sizeof(graphic_object_data) * graphics_object_update_data.offset,
+                                      sizeof(graphic_object_data) * updated.size(), updated.data());
                     // Clear out state so that we avoid unnecessary updates.
                     graphics_object_update_data.offset = 0;
                     graphics_object_update_data.graphic_objects.clear();

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -420,8 +420,8 @@ namespace
     struct graphic_object_data
     {
         [[maybe_unused]] std::array<float, 16> transform;
-        [[maybe_unused]] std::array<float, 16> normal_transform;
         [[maybe_unused]] std::array<float, 16> to_object_space_transform;
+        [[maybe_unused]] std::array<float, 9> normal_transform;
     };
 
     struct frame_data
@@ -4695,8 +4695,8 @@ namespace
             {
                 go_data.push_back({
                     .transform = go.transform,
-                    .normal_transform = go.normal_transform,
                     .to_object_space_transform = go.to_object_space_transform,
+                    .normal_transform = go.normal_transform,
                 });
                 for (const auto& s : go.surface_data)
                 {
@@ -5102,14 +5102,11 @@ namespace
                     {
                         updated.push_back({
                             .transform = gou.transform,
-                            .normal_transform = gou.normal_transform,
                             .to_object_space_transform = gou.to_object_space_transform,
+                            .normal_transform = gou.normal_transform,
                         });
                     }
-                    vkCmdUpdateBuffer(cf.command_buffer,
-                                      frame_datas[frame_to_update].graphic_objects_buffer.go_buffer.buffer,
-                                      sizeof(graphic_object_data) * graphics_object_update_data.offset,
-                                      sizeof(graphic_object_data) * updated.size(), updated.data());
+                    vkCmdUpdateBuffer(cf.command_buffer,  frame_datas[frame_to_update].graphic_objects_buffer.go_buffer.buffer, sizeof(graphic_object_data) * graphics_object_update_data.offset, sizeof(graphic_object_data) * updated.size(), updated.data());
                     // Clear out state so that we avoid unnecessary updates.
                     graphics_object_update_data.offset = 0;
                     graphics_object_update_data.graphic_objects.clear();

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -417,7 +417,7 @@ namespace
     {
         [[maybe_unused]] std::array<float, 16> transform;
         [[maybe_unused]] std::array<float, 16> normal_transform;
-        [[maybe_unused]] std::array<float, 16> object_space_transform;
+        [[maybe_unused]] std::array<float, 16> to_object_space_transform;
     };
 
     struct frame_data
@@ -4673,7 +4673,7 @@ namespace
                 go_data.push_back({
                     .transform = go.transform,
                     .normal_transform = go.normal_transform,
-                    .object_space_transform = go.object_space_transform,
+                    .to_object_space_transform = go.to_object_space_transform,
                 });
                 for (const auto& s : go.surface_data)
                 {
@@ -5080,7 +5080,7 @@ namespace
                         updated.push_back({
                             .transform = gou.transform,
                             .normal_transform = gou.normal_transform,
-                            .object_space_transform = gou.object_space_transform,
+                            .to_object_space_transform = gou.to_object_space_transform,
                         });
                     }
                     vkCmdUpdateBuffer(cf.command_buffer,

--- a/src/Engine/Graphics.cpp
+++ b/src/Engine/Graphics.cpp
@@ -6009,8 +6009,8 @@ namespace
             sd.shadow_projection_near = new_rls.cam.shadow_projection_near;
             sd.sunlight = new_rls.light.sunlight;
             sd.camera_position = new_rls.cam.position;
-            sd.ambient_color = {0.04f, 0.04f, 0.04f, 1.f};
-            sd.sunlight_color = {0.55f, 0.55f, 0.55f, 1.f};
+            sd.ambient_color = {new_rls.light.ambient_light, new_rls.light.ambient_light, new_rls.light.ambient_light, 1.f};
+            sd.sunlight_color = new_rls.light.sunlight_color;
             sd.flip_lights = {flip_x, flip_y, flip_z, 1};
             sd.flip_tangents = {flip_tangent_x, flip_tangent_y, flip_tangent_z, flip_tangent_w};
             sd.draw_extent = {static_cast<float>(swapchain_extent.width), static_cast<float>(swapchain_extent.height)};

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -1409,6 +1409,8 @@ result level::init(log* new_log, const config new_cfg)
             wls.light.depth_bias_clamp = -20.937f;
             wls.light.depth_bias_slope_factor = -3.922f;
             wls.draw_config.cull_enabled = true;
+            wls.light.sunlight_color = { 0.55f, 0.55f, 0.55f, 1.f };
+            wls.light.ambient_light = 0.04f;
             wls.light.depth_bias_enabled = true;
             wls.draw_config.thick_wire_lines = false;
             wls.fragment_config.output = 0;

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -1161,15 +1161,13 @@ namespace
                     c_forward nf{.yaw = target_yaw};
                     ecs_set_id(ctx->world, ctx->rosy_reference.entity, ecs_id(c_forward), sizeof(c_forward), &nf);
 
-                    // Set rosy's orientation to face target
-                    glm::quat yaw_rotation = angleAxis(target_yaw, glm::vec3{0.f, 1.f, 0.f});
-
                     // Linearly interpolate rosy's position toward the target
                     const float t = 1.f * it->delta_time;
                     glm::vec3 new_rosy_pos = (rosy_pos * (1.f - t)) + rosy_target * t;
 
                     // Update rosy's world space orientation and position
                     ctx->rosy_reference.node->set_world_space_translate(vec3_to_array(new_rosy_pos));
+                    // Set rosy's orientation to face target
                     ctx->rosy_reference.node->set_world_space_yaw(target_yaw);
 
                     ctx->game_cam->set_game_cam_position({new_rosy_pos[0], new_rosy_pos[1], new_rosy_pos[2]});

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -1028,11 +1028,10 @@ namespace
             const glm::vec3 intersection = m_x_n + d_v;
             const float intersection_w = glm::dot(-normal, plucker_v);
 
-            ctx->l->info(std::format("intersection {:.3f}, {:.3f}, {:.3f}", intersection[0] / intersection_w, intersection[1] / intersection_w, intersection[2] / intersection_w));
+            ctx->l->debug(std::format("intersection {:.3f}, {:.3f}, {:.3f}", intersection[0] / intersection_w, intersection[1] / intersection_w, intersection[2] / intersection_w));
 
             // Set rosy to target that intersection.
             auto rosy_target = glm::vec3(intersection[0] / intersection_w, intersection[1] / intersection_w, intersection[2] / intersection_w);
-            ctx->l->info(std::format("rosy_target huh00000? {:.3f}, {:.3f}, {:.3f}", rosy_target[0], rosy_target[1], rosy_target[2]));
 
             // Calculate whether the target is within the floor's bounds, if not set any coordinate outside to the max extent of the bounds.
             const auto floor_index = static_cast<const c_static*>(ecs_get_id(ctx->world, ctx->floor_entity, ecs_id(c_static)));
@@ -1040,29 +1039,24 @@ namespace
             // Transform world space rosy target to the actual floor meshes object space because that's the space the bounds are in.
             const glm::mat4 floor_world_space_transform = array_to_mat4(floor_node->get_world_space_transform());
             auto world_space_floor_bounds = floor_node->get_world_space_bounds();
-            ctx->l->info(std::format("rosy_target huh00000_8? {:.3f}, {:.3f}, {:.3f}", rosy_target[0], rosy_target[1], rosy_target[2]));
             for (int j{0}; j < 3; j++)
             {
                 if (rosy_target[j] < world_space_floor_bounds.min[j])
                 {
-                    ctx->l->info("min bound");
                     rosy_target[j] = world_space_floor_bounds.min[j];
                 }
                 if (rosy_target[j] > world_space_floor_bounds.max[j])
                 {
-                    ctx->l->info("max bound");
                     rosy_target[j] = world_space_floor_bounds.max[j];
                 }
             }
 
-            ctx->l->info(std::format("rosy_target huh00000_9? {:.3f}, {:.3f}, {:.3f}", rosy_target[0], rosy_target[1], rosy_target[2]));
             c_target target{.x = rosy_target.x, .y = rosy_target.y, .z = rosy_target.z};
             ecs_set_id(ctx->world, ctx->rosy_reference.entity, ecs_id(c_target), sizeof(c_target), &target);
 
             // Draw some debugging UI to display picking performance.
             if (ecs_has_id(ctx->world, ctx->level_entity, ecs_id(c_pick_debugging_enabled)))
             {
-                ctx->l->info(std::format("rosy_target huh000001? {:.3f}, {:.3f}, {:.3f}", rosy_target[0], rosy_target[1], rosy_target[2]));
                 const auto pick_debugging = static_cast<const c_pick_debugging_enabled*>(ecs_get_id(ctx->world, ctx->level_entity, ecs_id(c_pick_debugging_enabled)));
                 glm::mat4 m;
                 std::array<float, 4> color;
@@ -1122,11 +1116,9 @@ namespace
                     .flags = 0,
                 };
             }
-            ctx->l->info(std::format("rosy_target huh000002? {:.3f}, {:.3f}, {:.3f}", rosy_target[0], rosy_target[1], rosy_target[2]));
             // If rosy is targeting orient rosy and move her toward the target.
             if (ecs_has_id(ctx->world, ctx->rosy_reference.entity, ecs_id(c_target)))
             {
-                ctx->l->info(std::format("rosy_target huh000003? {:.3f}, {:.3f}, {:.3f}", rosy_target[0], rosy_target[1], rosy_target[2]));
                 const std::array<float, 3> node_world_space_position = ctx->rosy_reference.node->get_world_space_position();
                 const auto rosy_pos = glm::vec3(node_world_space_position[0], node_world_space_position[1], node_world_space_position[2]);
                 constexpr auto game_forward = glm::vec3(0.f, 0.f, 1.f);
@@ -1135,7 +1127,6 @@ namespace
                 // This works because rosy will be at origin in this space and so wherever the target is at an angle for rosy's position.
                 if (rosy_target != glm::zero<glm::vec3>())
                 {
-                    ctx->l->info(std::format("rosy_target huh000003a? {:.3f}, {:.3f}, {:.3f}", rosy_target[0], rosy_target[1], rosy_target[2]));
                     // Calculate the difference between rosy's orientation and her target position
                     const float offset = rosy_target.x > 0 ? 0.f : -1.f;
                     // This offset's rosy's orientation based on her orientation around the x-axis.
@@ -1145,7 +1136,6 @@ namespace
                     // This is negated because we of the handedness of the coordinate system.
                     const float new_yaw = target_yaw + offset;
 
-                    ctx->l->info(std::format("rosy_target huh000004? {:.3f}, {:.3f}, {:.3f}", rosy_target[0], rosy_target[1], rosy_target[2]));
                     ctx->l->info(std::format(
                         "target: ({:.3f}, {:.3f}, {:.3f}) cosTheta {:.3f}) yaw: {:.3f}) offset: {:.3f} new_yaw: {:.3f}",
                         rosy_target[0],

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -689,7 +689,6 @@ namespace
             }
 
             const std::array<float, 16> asset_coordinate_system_transform = new_asset.asset_coordinate_system;
-            glm::mat4 object_to_world_transform = array_to_mat4(asset_coordinate_system_transform);
 
             {
                 // Reset state
@@ -752,6 +751,19 @@ namespace
 
 
                 const glm::mat4 transform = array_to_mat4(queue_item.game_node->get_object_space_transform());
+
+                std::array<float, 16> node_coordinate_system = asset_coordinate_system_transform;
+                // Check if the node has its own coordinate system (because the nodes in the assets may come from different coordinate systems).
+                for (const float v : queue_item.stack_node.coordinate_system)
+                {
+                    if (std::abs(v) > 0.000001)
+                    {
+                        node_coordinate_system = queue_item.stack_node.coordinate_system;
+                        break;
+                    }
+                }
+                glm::mat4 object_to_world_transform = array_to_mat4(node_coordinate_system);
+
                 // Set node bounds for bound testing.
                 node_bounds bounds{};
                 // Advance the next item in the node queue
@@ -845,7 +857,7 @@ namespace
                     }
 
                     // Initialize its state
-                    if (const auto res = new_game_node->init(l,asset_coordinate_system_transform, mat4_to_array(transform), new_node.transform, new_node.world_translate, new_node.world_scale,
+                    if (const auto res = new_game_node->init(l, node_coordinate_system, mat4_to_array(transform), new_node.transform, new_node.world_translate, new_node.world_scale,
                                                              new_node.world_yaw);
                         res != result::ok)
                     {

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -135,6 +135,18 @@ namespace
         return a;
     }
 
+    std::array<float, 9> mat3_to_array(glm::mat3 m)
+    {
+        std::array<float, 9> a{
+            1.f, 0.f, 0.f,
+            0.f, 1.f, 0.f,
+            0.f, 0.f, 1.f,
+        };
+        const auto pos_r = glm::value_ptr(m);
+        for (size_t i{ 0 }; i < 9; i++) a[i] = pos_r[i];
+        return a;
+    }
+
     glm::mat4 array_to_mat4(const std::array<float, 16>& a)
     {
         glm::mat4 m{1.f};
@@ -775,12 +787,12 @@ namespace
 
                     {
                         // Record the assets transforms from the asset
-                        const glm::mat4 to_object_space_transform = glm::inverse(static_cast<glm::mat3>(node_world_space_transform));
-                        const glm::mat4 normal_transform = glm::transpose(to_object_space_transform);
+                        const glm::mat4 to_object_space_transform = glm::inverse(static_cast<glm::mat4>(node_world_space_transform));
+                        const glm::mat3 normal_transform = glm::transpose(glm::inverse(glm::mat3(node_world_space_transform)));
 
                         go.transform = mat4_to_array(node_world_space_transform);
-                        go.normal_transform = mat4_to_array(normal_transform);
                         go.to_object_space_transform = mat4_to_array(to_object_space_transform);
+                        go.normal_transform = mat3_to_array(normal_transform);
                     }
 
                     {

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -1153,7 +1153,7 @@ namespace
 
                     // Update rosy's transform.
                     const glm::mat4 tr = glm::translate(glm::mat4(1.f), new_rosy_pos);
-                    if (const auto res = ctx->rosy_reference.node->update_transform(mat4_to_array(tr * r)); res !=
+                    if (const auto res = ctx->rosy_reference.node->set_world_transform(mat4_to_array(tr * r)); res !=
                         result::ok)
                     {
                         ctx->l->error("error transforming rosy");
@@ -1203,7 +1203,7 @@ namespace
                 ctx->rls->mob_read.clear_edits = true;
                 if (mobs.size() > ctx->wls->mob_edit.edit_index)
                 {
-                    if (const auto res = mobs[0]->set_position(ctx->wls->mob_edit.position); res != result::ok)
+                    if (const auto res = mobs[0]->set_world_translate(ctx->wls->mob_edit.position); res != result::ok)
                     {
                         ctx->l->error("Error updating mob position");
                     }

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -143,7 +143,7 @@ namespace
             0.f, 0.f, 1.f,
         };
         const auto pos_r = glm::value_ptr(m);
-        for (size_t i{ 0 }; i < 9; i++) a[i] = pos_r[i];
+        for (size_t i{0}; i < 9; i++) a[i] = pos_r[i];
         return a;
     }
 
@@ -1288,25 +1288,16 @@ namespace
                 // Lighting math
 
                 {
-                    const glm::mat4 light_translate = glm::translate(glm::mat4(1.f), {
-                                                                         0.f, 0.f,
-                                                                         1.f * ctx->wls->light_debug.sun_distance
-                                                                     });
-                    debug_light_translate = glm::translate(glm::mat4(1.f), {
-                                                               0.f, 0.f, -1.f * ctx->wls->light_debug.sun_distance
-                                                           });
-                    const glm::quat pitch_rotation = angleAxis(-ctx->wls->light_debug.sun_pitch,
-                                                               glm::vec3{1.f, 0.f, 0.f});
+                    const glm::mat4 light_translate = glm::translate(glm::mat4(1.f), {0.f, 0.f, 1.f * ctx->wls->light_debug.sun_distance});
+                    debug_light_translate = glm::translate(glm::mat4(1.f), {0.f, 0.f, -1.f * ctx->wls->light_debug.sun_distance});
+                    const glm::quat pitch_rotation = angleAxis(-ctx->wls->light_debug.sun_pitch, glm::vec3{1.f, 0.f, 0.f});
                     const glm::quat yaw_rotation = angleAxis(ctx->wls->light_debug.sun_yaw, glm::vec3{0.f, -1.f, 0.f});
                     light_line_rot = toMat4(yaw_rotation) * toMat4(pitch_rotation);
 
-                    const auto camera_position = glm::vec3(
-                        light_line_rot * glm::vec4(0.f, 0.f, -ctx->wls->light_debug.sun_distance, 0.f));
+                    const auto camera_position = glm::vec3(light_line_rot * glm::vec4(0.f, 0.f, -ctx->wls->light_debug.sun_distance, 0.f));
                     auto sunlight = glm::vec4(glm::normalize(camera_position), 1.f);
                     light_sun_view = light_line_rot * light_translate;
-                    debug_light_sun_view = light_line_rot * (ctx->wls->light_debug.enable_light_perspective
-                                                                 ? light_translate
-                                                                 : debug_light_translate);
+                    debug_light_sun_view = light_line_rot * (ctx->wls->light_debug.enable_light_perspective ? light_translate : debug_light_translate);
 
                     ctx->rls->light.sunlight = {sunlight[0], sunlight[1], sunlight[2], sunlight[3]};
                 };
@@ -1316,11 +1307,7 @@ namespace
             {
                 // Generate debug lines for light and shadow debugging
                 const glm::mat4 debug_draw_view = light_line_rot * debug_light_translate;
-                const glm::mat4 debug_light_line = glm::scale(debug_draw_view, {
-                                                                  ctx->wls->light_debug.sun_distance,
-                                                                  ctx->wls->light_debug.sun_distance,
-                                                                  ctx->wls->light_debug.sun_distance
-                                                              });
+                const glm::mat4 debug_light_line = glm::scale(debug_draw_view, {ctx->wls->light_debug.sun_distance, ctx->wls->light_debug.sun_distance, ctx->wls->light_debug.sun_distance});
 
                 debug_object line;
                 line.type = debug_object_type::line;
@@ -1421,7 +1408,7 @@ result level::init(log* new_log, const config new_cfg)
             wls.light.depth_bias_clamp = -20.937f;
             wls.light.depth_bias_slope_factor = -3.922f;
             wls.draw_config.cull_enabled = true;
-            wls.light.sunlight_color = { 0.55f, 0.55f, 0.55f, 1.f };
+            wls.light.sunlight_color = {0.55f, 0.55f, 0.55f, 1.f};
             wls.light.ambient_light = 0.04f;
             wls.light.depth_bias_enabled = true;
             wls.draw_config.thick_wire_lines = false;

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -788,20 +788,20 @@ namespace
                         go.surface_data.reserve(current_mesh.surfaces.size());
                         for (const auto& surf : current_mesh.surfaces)
                         {
-                            glm::vec4 min_bounds = { surf.min_bounds[0], surf.min_bounds[1], surf.min_bounds[2], 1.f };
-                            glm::vec4 max_bounds = { surf.max_bounds[0], surf.max_bounds[1], surf.max_bounds[2], 1.f };
-                            max_bounds = node_world_space_transform * min_bounds;
-                            min_bounds = node_world_space_transform * max_bounds;
+                            glm::vec4 os_min_bounds = { surf.min_bounds[0], surf.min_bounds[1], surf.min_bounds[2], 1.f };
+                            glm::vec4 os_max_bounds = { surf.max_bounds[0], surf.max_bounds[1], surf.max_bounds[2], 1.f };
+                            glm::vec4 ws_min_bounds = node_world_space_transform * os_min_bounds;
+                            glm::vec4 ws_max_bounds = node_world_space_transform * os_max_bounds;
                             for (glm::length_t i{0}; i < 3; i++)
                             {
-                                if (min_bounds[i] > max_bounds[i])
+                                if (ws_min_bounds[i] > ws_max_bounds[i])
                                 {
-                                    float s = min_bounds[i];
-                                    min_bounds[i] = max_bounds[i];
-                                    max_bounds[i] = s;
+                                    float s = ws_min_bounds[i];
+                                    ws_min_bounds[i] = ws_max_bounds[i];
+                                    ws_max_bounds[i] = s;
                                 }
-                                world_space_bounds.min[i] = glm::min(min_bounds[i], world_space_bounds.min[i]);
-                                world_space_bounds.max[i] = glm::max(max_bounds[i], world_space_bounds.max[i]);
+                                world_space_bounds.min[i] = glm::min(ws_min_bounds[i], world_space_bounds.min[i]);
+                                world_space_bounds.max[i] = glm::max(ws_max_bounds[i], world_space_bounds.max[i]);
                             }
                             surface_graphics_data sgd{};
                             sgd.mesh_index = current_mesh_index;

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -750,7 +750,7 @@ namespace
                 assert(queue_item.game_node != nullptr);
 
 
-                constexpr glm::mat4 parent_transform = array_to_mat4(queue_item.game_node->get_object_space_transform());
+                const glm::mat4 parent_transform = array_to_mat4(queue_item.game_node->get_object_space_transform());
 
                 glm::mat4 node_transform = parent_transform * array_to_mat4(queue_item.stack_node.transform);
 

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -704,7 +704,7 @@ namespace
                 const std::array<float, 16> identity_m = mat4_to_array(glm::mat4(1.f));
 
                 // All nodes must be initialized here and below.
-                if (const auto res = new_game_node->init(l, new_node.transform, identity_m, new_node.custom_translate, new_node.custom_uniform_scale, new_node.custom_yaw); res !=
+                if (const auto res = new_game_node->init(l, new_node.transform, identity_m, new_node.world_translate, new_node.world_scale, new_node.world_yaw); res !=
                     result::ok)
                 {
                     l->error("initial scene_objects initialization failed");
@@ -743,10 +743,10 @@ namespace
 
 
                 constexpr glm::mat4 m{1.f};
-                const glm::mat4 t = glm::translate(m, array_to_vec3(queue_item.game_node->custom_translate));
-                const glm::mat4 r = toMat4(angleAxis(queue_item.game_node->custom_yaw, glm::vec3{0.f, 1.f, 0.f}));
-                float custom_scale = queue_item.game_node->custom_scale;
-                const glm::mat4 s = glm::scale(m, glm::vec3(custom_scale, custom_scale, custom_scale));
+                const glm::mat4 t = glm::translate(m, array_to_vec3(queue_item.game_node->world_translate));
+                const glm::mat4 r = toMat4(angleAxis(queue_item.game_node->world_yaw, glm::vec3{0.f, 1.f, 0.f}));
+                float world_scale = queue_item.game_node->world_scale;
+                const glm::mat4 s = glm::scale(m, glm::vec3(world_scale, world_scale, world_scale));
 
                 glm::mat4 node_transform = t * r * s * array_to_mat4(queue_item.stack_node.transform);
 
@@ -844,8 +844,8 @@ namespace
                     }
 
                     // Initialize its state
-                    if (const auto res = new_game_node->init(l, mat4_to_array(transform), mat4_to_array(node_transform), new_node.custom_translate, new_node.custom_uniform_scale,
-                                                             new_node.custom_yaw);
+                    if (const auto res = new_game_node->init(l, mat4_to_array(transform), mat4_to_array(node_transform), new_node.world_translate, new_node.world_scale,
+                                                             new_node.world_yaw);
                         res != result::ok)
                     {
                         l->error("Error initializing new game node in set asset");

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -689,6 +689,7 @@ namespace
             }
 
             const std::array<float, 16> asset_coordinate_system_transform = new_asset.asset_coordinate_system;
+            glm::mat4 object_to_world_transform = array_to_mat4(asset_coordinate_system_transform);
 
             {
                 // Reset state
@@ -772,12 +773,12 @@ namespace
 
                     {
                         // Record the assets transforms from the asset
-                        const glm::mat4 object_space_transform = glm::inverse(static_cast<glm::mat3>(transform));
-                        const glm::mat4 normal_transform = glm::transpose(object_space_transform);
+                        const glm::mat4 to_object_space_transform = glm::inverse(static_cast<glm::mat3>(object_to_world_transform * transform));
+                        const glm::mat4 normal_transform = glm::transpose(to_object_space_transform);
 
-                        go.transform = mat4_to_array(transform);
+                        go.transform = mat4_to_array(object_to_world_transform * transform);
                         go.normal_transform = mat4_to_array(normal_transform);
-                        go.to_object_space_transform = mat4_to_array(object_space_transform);
+                        go.to_object_space_transform = mat4_to_array(to_object_space_transform);
                     }
 
                     {
@@ -844,7 +845,7 @@ namespace
                     }
 
                     // Initialize its state
-                    if (const auto res = new_game_node->init(l,asset_coordinate_system_transform, mat4_to_array(transform), mat4_to_array(transform), new_node.world_translate, new_node.world_scale,
+                    if (const auto res = new_game_node->init(l,asset_coordinate_system_transform, mat4_to_array(transform), new_node.transform, new_node.world_translate, new_node.world_scale,
                                                              new_node.world_yaw);
                         res != result::ok)
                     {

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -1415,6 +1415,7 @@ result level::init(log* new_log, const config new_cfg)
             wls.fragment_config.light_enabled = true;
             wls.fragment_config.tangent_space_enabled = true;
             wls.fragment_config.shadows_enabled = true;
+            wls.fragment_config.normal_maps_enabled = true;
             wls.target_fps = initial_fps_target;
             rls.ui_enabled = true;
         }

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -222,7 +222,7 @@ namespace
                 l->error("root scene_objects allocation failed");
                 return result::allocation_failure;
             };
-            if (const auto res = level_game_node->init(l, {},  {}, {}, {}, 1.f, 0.f); res != result::ok)
+            if (const auto res = level_game_node->init(l, false, {},  {}, {}, {}, 1.f, 0.f); res != result::ok)
             {
                 l->error("root scene_objects initialization failed");
                 delete level_game_node;
@@ -712,7 +712,7 @@ namespace
                 const std::array<float, 16> identity_m = mat4_to_array(glm::mat4(1.f));
 
                 // All nodes must be initialized here and below.
-                if (const auto res = new_game_node->init(l, asset_coordinate_system_transform, identity_m, new_node.transform, new_node.world_translate, new_node.world_scale, new_node.world_yaw); res !=
+                if (const auto res = new_game_node->init(l, false, asset_coordinate_system_transform, identity_m, new_node.transform, new_node.world_translate, new_node.world_scale, new_node.world_yaw); res !=
                     result::ok)
                 {
                     l->error("initial scene_objects initialization failed");
@@ -857,7 +857,7 @@ namespace
                     }
 
                     // Initialize its state
-                    if (const auto res = new_game_node->init(l, node_coordinate_system, mat4_to_array(node_object_space_transform), new_asset_node.transform, new_asset_node.world_translate, new_asset_node.world_scale,
+                    if (const auto res = new_game_node->init(l, new_asset_node.is_world_node, node_coordinate_system, mat4_to_array(node_object_space_transform), new_asset_node.transform, new_asset_node.world_translate, new_asset_node.world_scale,
                                                              new_asset_node.world_yaw);
                         res != result::ok)
                     {

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -131,7 +131,7 @@ namespace
             0.f, 0.f, 0.f, 1.f,
         };
         const auto pos_r = glm::value_ptr(m);
-        for (uint64_t i{0}; i < 16; i++) a[i] = pos_r[i];
+        for (size_t i{0}; i < 16; i++) a[i] = pos_r[i];
         return a;
     }
 
@@ -139,7 +139,7 @@ namespace
     {
         glm::mat4 m{1.f};
         const auto pos_r = glm::value_ptr(m);
-        for (uint64_t i{0}; i < 16; i++) pos_r[i] = a[i];
+        for (size_t i{0}; i < 16; i++) pos_r[i] = a[i];
         return m;
     }
 
@@ -147,7 +147,7 @@ namespace
     {
         glm::vec4 v{};
         const auto pos_r = glm::value_ptr(v);
-        for (uint64_t i{0}; i < 4; i++) pos_r[i] = a[i];
+        for (size_t i{0}; i < 4; i++) pos_r[i] = a[i];
         return v;
     }
 
@@ -155,14 +155,14 @@ namespace
     {
         glm::vec3 v{};
         const auto pos_r = glm::value_ptr(v);
-        for (uint64_t i{0}; i < 3; i++) pos_r[i] = a[i];
+        for (size_t i{0}; i < 3; i++) pos_r[i] = a[i];
         return v;
     }
 
     std::array<float, 3> vec3_to_array(glm::vec3 v)
     {
         std::array<float, 3> a{};
-        for (uint64_t i{ 0 }; i < 3; i++) a[i] = v[i];
+        for (size_t i{ 0 }; i < 3; i++) a[i] = v[static_cast<glm::length_t>(i)];
         return a;
     }
 

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -1153,7 +1153,7 @@ namespace
                     const float t = 1.f * it->delta_time;
                     glm::vec3 new_rosy_pos = (rosy_pos * (1.f - t)) + rosy_target * t;
 
-                    // Update rosy's world space orientationa nd position
+                    // Update rosy's world space orientation and position
                     ctx->rosy_reference.node->set_world_space_translate(vec3_to_array(new_rosy_pos));
                     ctx->rosy_reference.node->set_world_space_yaw(target_yaw);
 
@@ -1461,6 +1461,7 @@ result level::update(const uint32_t viewport_width, const uint32_t viewport_heig
     return result::ok;
 }
 
+// ReSharper disable once CppMemberFunctionMayBeStatic
 result level::process()
 {
     ls->rls->go_update.offset = ls->static_objects_offset;

--- a/src/Engine/Level.cpp
+++ b/src/Engine/Level.cpp
@@ -750,11 +750,7 @@ namespace
                 assert(queue_item.game_node != nullptr);
 
 
-                const glm::mat4 parent_transform = array_to_mat4(queue_item.game_node->get_object_space_transform());
-
-                glm::mat4 node_transform = parent_transform * array_to_mat4(queue_item.stack_node.transform);
-
-                const glm::mat4 transform = queue_item.parent_transform * node_transform;
+                const glm::mat4 transform = array_to_mat4(queue_item.game_node->get_object_space_transform());
                 // Set node bounds for bound testing.
                 node_bounds bounds{};
                 // Advance the next item in the node queue
@@ -848,7 +844,7 @@ namespace
                     }
 
                     // Initialize its state
-                    if (const auto res = new_game_node->init(l,asset_coordinate_system_transform, mat4_to_array(node_transform), mat4_to_array(transform), new_node.world_translate, new_node.world_scale,
+                    if (const auto res = new_game_node->init(l,asset_coordinate_system_transform, mat4_to_array(transform), mat4_to_array(transform), new_node.world_translate, new_node.world_scale,
                                                              new_node.world_yaw);
                         res != result::ok)
                     {
@@ -871,7 +867,7 @@ namespace
                     queue.push({
                         .game_node = new_game_node,
                         .stack_node = new_node,
-                        .parent_transform = queue_item.parent_transform * node_transform,
+                        .parent_transform = queue_item.parent_transform * transform,
                         .is_mob = is_mob,
                     });
                 }

--- a/src/Engine/Node.cpp
+++ b/src/Engine/Node.cpp
@@ -57,15 +57,15 @@ struct node_state
     glm::vec4 position{};
 
     void set_transform(const std::array<float, 16>& new_transform, const std::array<float, 16>& new_parent_transform,
-                       const std::array<float, 3> custom_translate, const float custom_scale, const float custom_yaw)
+                       const std::array<float, 3> world_translate, const float world_scale, const float world_yaw)
     {
         parent_transform = array_to_mat4(new_parent_transform);
         transform = array_to_mat4(new_transform);
 
         constexpr glm::mat4 m{1.f};
-        const glm::mat4 t = glm::translate(m, array_to_vec3(custom_translate));
-        const glm::mat4 r = toMat4(angleAxis(custom_yaw, glm::vec3{0.f, 1.f, 0.f}));
-        const glm::mat4 s = glm::scale(m, glm::vec3(custom_scale, custom_scale, custom_scale));
+        const glm::mat4 t = glm::translate(m, array_to_vec3(world_translate));
+        const glm::mat4 r = toMat4(angleAxis(world_yaw, glm::vec3{0.f, 1.f, 0.f}));
+        const glm::mat4 s = glm::scale(m, glm::vec3(world_scale, world_scale, world_scale));
 
         transform = t * r * s * transform;
         const glm::mat4 final_transform = parent_transform * transform;
@@ -107,7 +107,7 @@ struct node_state
 };
 
 result node::init(rosy::log* new_log, const std::array<float, 16>& new_transform, const std::array<float, 16>& new_parent_transform,
-                  const std::array<float, 3> new_custom_translate, const float new_custom_scale, const float new_custom_yaw)
+                  const std::array<float, 3> new_world_translate, const float new_world_scale, const float new_world_yaw)
 {
     l = new_log;
     if (ns = new(std::nothrow) node_state; ns == nullptr)
@@ -115,14 +115,14 @@ result node::init(rosy::log* new_log, const std::array<float, 16>& new_transform
         l->error("Error allocating node state");
         return result::allocation_failure;
     }
-    ns->set_transform(new_transform, new_parent_transform, new_custom_translate, new_custom_scale, new_custom_yaw);
+    ns->set_transform(new_transform, new_parent_transform, new_world_translate, new_world_scale, new_world_yaw);
     transform = mat4_to_array(ns->parent_transform * ns->transform);
     object_space_transform = mat4_to_array(ns->object_space_transform);
     normal_transform = mat4_to_array(ns->normal_transform);
     position = vec4_to_array(ns->position);
-    custom_translate = new_custom_translate;
-    custom_scale = new_custom_scale;
-    custom_yaw = new_custom_yaw;
+    world_translate = new_world_translate;
+    world_scale = new_world_scale;
+    world_yaw = new_world_yaw;
     return result::ok;
 }
 

--- a/src/Engine/Node.cpp
+++ b/src/Engine/Node.cpp
@@ -50,6 +50,8 @@ namespace
 
 struct node_state
 {
+    rosy::log* l{nullptr};
+    bool is_world_node{false};
     glm::mat4 object_to_world_transform{};
     glm::mat4 object_space_parent_transform{};
     glm::mat4 object_space_transform{};
@@ -58,6 +60,8 @@ struct node_state
     float world_space_yaw{0.f};
 
     void init(
+        rosy::log* new_log,
+        const bool new_is_world_node,
         const std::array<float, 16>& coordinate_space_transform,
         const std::array<float, 16>& new_object_space_parent_transform,
         const std::array<float, 16>& new_object_space_transform,
@@ -66,6 +70,8 @@ struct node_state
         const float new_world_space_yaw
     )
     {
+        l = new_log;
+        is_world_node = new_is_world_node;
         object_to_world_transform = array_to_mat4(coordinate_space_transform);
         object_space_parent_transform = array_to_mat4(new_object_space_parent_transform);
         object_space_transform = array_to_mat4(new_object_space_transform);
@@ -91,6 +97,7 @@ struct node_state
 
 result node::init(
     rosy::log* new_log,
+    bool is_world_node,
     const std::array<float, 16>& coordinate_space,
     const std::array<float, 16>& new_object_space_parent_transform,
     const std::array<float, 16>& new_object_space_transform,
@@ -104,6 +111,8 @@ result node::init(
         return result::allocation_failure;
     }
     ns->init(
+        l,
+        is_world_node,
         coordinate_space,
         new_object_space_parent_transform,
         new_object_space_transform,
@@ -153,7 +162,7 @@ std::array<float, 16> node::get_world_space_transform() const
 std::array<float, 3> node::get_world_space_position() const
 {
     const auto rv = vec4_to_array(ns->get_world_space_transform() * glm::vec4(0.f, 0.f, 0.f, 1.f));
-    return { rv[0], rv[1], rv[2] };
+    return {rv[0], rv[1], rv[2]};
 }
 
 void node::update_object_space_parent_transform(const std::array<float, 16>& new_parent_transform) const

--- a/src/Engine/Node.cpp
+++ b/src/Engine/Node.cpp
@@ -159,6 +159,15 @@ std::array<float, 16> node::get_world_space_transform() const
     return mat4_to_array(ns->get_world_space_transform());
 }
 
+std::array<float, 16> node::get_to_object_space_transform() const
+{
+    const glm::mat4 world_space_transform = ns->get_world_space_transform();
+    const glm::mat4 world_to_object_space_transform = inverse(world_space_transform);
+    const glm::mat4 world_space_normal_transform = transpose(world_to_object_space_transform);
+
+    return mat4_to_array(world_space_normal_transform);
+}
+
 std::array<float, 3> node::get_world_space_position() const
 {
     const auto rv = vec4_to_array(ns->get_world_space_transform() * glm::vec4(0.f, 0.f, 0.f, 1.f));

--- a/src/Engine/Node.cpp
+++ b/src/Engine/Node.cpp
@@ -50,64 +50,47 @@ namespace
 
 struct node_state
 {
-    glm::mat4 parent_transform{};
-    glm::mat4 transform{};
+    glm::mat4 object_to_world_transform{};
+    glm::mat4 object_space_parent_transform{};
     glm::mat4 object_space_transform{};
-    glm::mat4 normal_transform{};
-    glm::vec4 position{};
+    glm::vec3 world_space_translate{};
+    float world_space_scale{1.f};
+    float world_space_yaw{0.f};
 
-    void set_transform(const std::array<float, 16>& new_transform, const std::array<float, 16>& new_parent_transform,
-                       const std::array<float, 3> world_translate, const float world_scale, const float world_yaw)
+    void init(
+        const std::array<float, 16>& coordinate_space_transform,
+        const std::array<float, 16>& new_object_space_parent_transform,
+        const std::array<float, 16>& new_object_space_transform,
+        const std::array<float, 3> new_world_space_translate,
+        const float new_world_space_scale,
+        const float new_world_space_yaw
+    )
     {
-        parent_transform = array_to_mat4(new_parent_transform);
-        transform = array_to_mat4(new_transform);
-
-        constexpr glm::mat4 m{1.f};
-        const glm::mat4 t = glm::translate(m, array_to_vec3(world_translate));
-        const glm::mat4 r = toMat4(angleAxis(world_yaw, glm::vec3{0.f, 1.f, 0.f}));
-        const glm::mat4 s = glm::scale(m, glm::vec3(world_scale, world_scale, world_scale));
-
-        transform = t * r * s * transform;
-        const glm::mat4 final_transform = parent_transform * transform;
-
-        position = final_transform * glm::vec4(0.f, 0.f, 0.f, 1.f);
-        object_space_transform = glm::inverse(static_cast<glm::mat3>(final_transform));
-        normal_transform = glm::transpose(object_space_transform);
+        object_to_world_transform = array_to_mat4(coordinate_space_transform);
+        object_space_parent_transform = array_to_mat4(new_object_space_parent_transform);
+        object_space_transform = array_to_mat4(new_object_space_transform);
+        world_space_translate = array_to_vec3(new_world_space_translate);
+        world_space_scale = new_world_space_scale;
+        world_space_yaw = new_world_space_yaw;
     }
 
-    void update_transform(const std::array<float, 16>& new_transform)
+    [[nodiscard]] glm::mat4 get_world_space_transform() const
     {
-        transform = array_to_mat4(new_transform);
-        const glm::mat4 final_transform = parent_transform * transform;
+        const glm::mat4 t = translate(glm::mat4(1.f), world_space_translate);
+        const glm::mat4 r = toMat4(angleAxis(world_space_yaw, glm::vec3{0.f, -1.f, 0.f}));
+        const glm::mat4 s = scale(glm::mat4(1.f), glm::vec3(world_space_scale, world_space_scale, world_space_scale));
 
-        position = final_transform * glm::vec4(0.f, 0.f, 0.f, 1.f);
-        object_space_transform = glm::inverse(static_cast<glm::mat3>(final_transform));
-        normal_transform = glm::transpose(object_space_transform);
-    }
-
-    void update_parent_transform(const std::array<float, 16>& new_parent_transform)
-    {
-        parent_transform = array_to_mat4(new_parent_transform);
-        position = transform * glm::vec4(0.f, 0.f, 0.f, 1.f);
-    }
-
-    void set_position(const std::array<float, 3>& new_position)
-    {
-        position = glm::vec4(new_position[0], new_position[1], new_position[2], 1.f);
-        transform = glm::mat4(
-            transform[0],
-            transform[1],
-            transform[2],
-            position
-        );
-
-        object_space_transform = glm::inverse(static_cast<glm::mat3>(parent_transform * transform));
-        normal_transform = glm::transpose(object_space_transform);
+        return t * r * s * object_to_world_transform * object_space_parent_transform * object_space_transform;
     }
 };
 
-result node::init(rosy::log* new_log, const std::array<float, 16>& new_transform, const std::array<float, 16>& new_parent_transform,
-                  const std::array<float, 3> new_world_translate, const float new_world_scale, const float new_world_yaw)
+result node::init(
+    rosy::log* new_log,
+    const std::array<float, 16>& coordinate_space,
+    const std::array<float, 16>& new_object_space_parent_transform,
+    const std::array<float, 16>& new_object_space_transform,
+    const std::array<float, 3> new_world_translate,
+    const float new_world_scale, const float new_world_yaw)
 {
     l = new_log;
     if (ns = new(std::nothrow) node_state; ns == nullptr)
@@ -115,14 +98,13 @@ result node::init(rosy::log* new_log, const std::array<float, 16>& new_transform
         l->error("Error allocating node state");
         return result::allocation_failure;
     }
-    ns->set_transform(new_transform, new_parent_transform, new_world_translate, new_world_scale, new_world_yaw);
-    transform = mat4_to_array(ns->parent_transform * ns->transform);
-    object_space_transform = mat4_to_array(ns->object_space_transform);
-    normal_transform = mat4_to_array(ns->normal_transform);
-    position = vec4_to_array(ns->position);
-    world_translate = new_world_translate;
-    world_scale = new_world_scale;
-    world_yaw = new_world_yaw;
+    ns->init(
+        coordinate_space,
+        new_object_space_parent_transform,
+        new_object_space_transform,
+        new_world_translate,
+        new_world_scale,
+        new_world_yaw);
     return result::ok;
 }
 
@@ -138,60 +120,51 @@ void node::deinit()
     ns = nullptr;
 }
 
-result node::set_position(const std::array<float, 3>& new_position)
+void node::set_world_space_translate(const std::array<float, 3>& new_world_space_translate) const
 {
-    ns->set_position(new_position);
-    transform = mat4_to_array(ns->parent_transform * ns->transform);
-    position = vec4_to_array(ns->position);
-    object_space_transform = mat4_to_array(ns->object_space_transform);
-    normal_transform = mat4_to_array(ns->normal_transform);
-    for (node* n : children)
-    {
-        n->update_parent_transform(transform);
-    }
-    return result::ok;
+    ns->world_space_translate = array_to_vec3(new_world_space_translate);
 }
 
-result node::update_transform(const std::array<float, 16>& new_parent_transform)
+void node::set_world_space_scale(const float new_world_space_scale) const
 {
-    ns->update_transform(new_parent_transform);
-    transform = mat4_to_array(ns->parent_transform * ns->transform);
-    position = vec4_to_array(ns->position);
-    if (std::isnan(position[0]) || std::isnan(position[1]) || std::isnan(position[2]))
-    {
-        l->error("update_transform: error nan");
-        return result::error;
-    }
-    object_space_transform = mat4_to_array(ns->object_space_transform);
-    normal_transform = mat4_to_array(ns->normal_transform);
-    for (node* n : children)
-    {
-        n->update_parent_transform(transform);
-    }
-    return result::ok;
+    ns->world_space_scale = new_world_space_scale;
 }
 
-void node::update_parent_transform(const std::array<float, 16>& new_parent_transform)
+void node::set_world_space_yaw(const float new_world_space_yaw) const
 {
-    ns->update_parent_transform(new_parent_transform);
-    transform = mat4_to_array(ns->parent_transform * ns->transform);
-    position = vec4_to_array(ns->position);
-    object_space_transform = mat4_to_array(ns->object_space_transform);
-    normal_transform = mat4_to_array(ns->normal_transform);
-    for (node* n : children)
+    ns->world_space_yaw = new_world_space_yaw;
+}
+
+std::array<float, 16> node::get_world_space_transform() const
+{
+    return mat4_to_array(ns->get_world_space_transform());
+}
+
+void node::update_object_space_parent_transform(const std::array<float, 16>& new_parent_transform) const
+{
+    ns->object_space_parent_transform = array_to_mat4(new_parent_transform);
+    for (const node* n : children)
     {
-        n->update_parent_transform(transform);
+        n->update_object_space_parent_transform(mat4_to_array(ns->object_space_parent_transform * ns->object_space_transform));
     }
 }
 
 void node::populate_graph(std::vector<graphics_object>& graph) const
 {
+    const glm::mat4 world_space_transform = ns->get_world_space_transform();
+    const glm::mat4 world_to_object_space_transform = inverse(world_space_transform);
+    const glm::mat4 world_space_normal_transform = transpose(world_to_object_space_transform);
+
+    const std::array<float, 16> go_transform = mat4_to_array(world_space_transform);
+    const std::array<float, 16> go_normal_transform = mat4_to_array(world_space_normal_transform);
+    const std::array<float, 16> go_to_object_space_transform = mat4_to_array(world_space_normal_transform);
+
     for (graphics_object go : graphics_objects)
     {
         assert(graph.size() > go.index);
-        go.transform = transform;
-        go.normal_transform = normal_transform;
-        go.object_space_transform = object_space_transform;
+        go.transform = go_transform;
+        go.normal_transform = go_normal_transform;
+        go.to_object_space_transform = go_to_object_space_transform;
         graph[go.index] = go;
     }
     for (const node* n : children)
@@ -204,8 +177,7 @@ void node::debug()
 {
     size_t num_surfaces{0};
     for (const auto& go : graphics_objects) num_surfaces += go.surface_data.size();
-    l->debug(std::format("game node name: {} num graphic objects: {} num surfaces: {}", name, graphics_objects.size(),
-                         num_surfaces));
+    l->debug(std::format("game node name: {} num graphic objects: {} num surfaces: {}", name, graphics_objects.size(), num_surfaces));
     for (node* n : children)
     {
         n->debug();

--- a/src/Engine/Node.cpp
+++ b/src/Engine/Node.cpp
@@ -23,6 +23,18 @@ namespace
         return a;
     }
 
+    std::array<float, 9> mat3_to_array(glm::mat3 m)
+    {
+        std::array<float, 9> a{
+            1.f, 0.f, 0.f,
+            0.f, 1.f, 0.f,
+            0.f, 0.f, 1.f,
+        };
+        const auto pos_r = glm::value_ptr(m);
+        for (size_t i{ 0 }; i < 9; i++) a[i] = pos_r[i];
+        return a;
+    }
+
     glm::mat4 array_to_mat4(const std::array<float, 16>& a)
     {
         glm::mat4 m{};
@@ -213,11 +225,11 @@ void node::populate_graph(std::vector<graphics_object>& graph) const
 {
     const glm::mat4 world_space_transform = ns->get_world_space_transform();
     const glm::mat4 world_to_object_space_transform = inverse(world_space_transform);
-    const glm::mat4 world_space_normal_transform = transpose(world_to_object_space_transform);
+    const glm::mat3 world_space_normal_transform = glm::transpose(glm::inverse(glm::mat3(world_space_transform)));
 
     const std::array<float, 16> go_transform = mat4_to_array(world_space_transform);
-    const std::array<float, 16> go_normal_transform = mat4_to_array(world_space_normal_transform);
-    const std::array<float, 16> go_to_object_space_transform = mat4_to_array(world_space_normal_transform);
+    const std::array<float, 16> go_to_object_space_transform = mat4_to_array(world_to_object_space_transform);
+    const std::array<float, 9> go_normal_transform = mat3_to_array(world_space_normal_transform);
 
     for (graphics_object go : graphics_objects)
     {

--- a/src/Engine/Node.cpp
+++ b/src/Engine/Node.cpp
@@ -82,6 +82,11 @@ struct node_state
 
         return t * r * s * object_to_world_transform * object_space_parent_transform * object_space_transform;
     }
+
+    [[nodiscard]] glm::mat4 get_object_space_transform() const
+    {
+        return object_space_parent_transform * object_space_transform;
+    }
 };
 
 result node::init(
@@ -135,9 +140,20 @@ void node::set_world_space_yaw(const float new_world_space_yaw) const
     ns->world_space_yaw = new_world_space_yaw;
 }
 
+std::array<float, 16> node::get_object_space_transform() const
+{
+    return mat4_to_array(ns->get_object_space_transform());
+}
+
 std::array<float, 16> node::get_world_space_transform() const
 {
     return mat4_to_array(ns->get_world_space_transform());
+}
+
+std::array<float, 3> node::get_world_space_position() const
+{
+    const auto rv = vec4_to_array(ns->get_world_space_transform() * glm::vec4(0.f, 0.f, 0.f, 1.f));
+    return { rv[0], rv[1], rv[2] };
 }
 
 void node::update_object_space_parent_transform(const std::array<float, 16>& new_parent_transform) const

--- a/src/Engine/Node.h
+++ b/src/Engine/Node.h
@@ -48,13 +48,13 @@ namespace rosy
             0.f, 0.f, 0.f, 1.f,
         };
         std::array<float, 4> position{};
-        std::array<float, 3> custom_translate{};
-        float custom_scale{1.f};
-        float custom_yaw{0.f};
+        std::array<float, 3> world_translate{};
+        float world_scale{1.f};
+        float world_yaw{0.f};
         node_bounds bounds{};
 
         [[nodiscard]] result init(log* new_log, const std::array<float, 16>& new_transform, const std::array<float, 16>& new_parent_transform,
-                                  const std::array<float, 3> new_custom_translate, float new_custom_scale, float new_custom_yaw);
+                                  const std::array<float, 3> new_world_translate, float new_world_scale, float new_world_yaw);
         void deinit();
         [[nodiscard]] result set_position(const std::array<float, 3>& new_position);
         [[nodiscard]] result update_transform(const std::array<float, 16>& new_parent_transform);

--- a/src/Engine/Node.h
+++ b/src/Engine/Node.h
@@ -37,7 +37,19 @@ namespace rosy
         void set_world_space_translate(const std::array<float, 3>& new_world_space_translate) const;
         void set_world_space_scale(const float new_world_space_scale) const;
         void set_world_space_yaw(float new_world_space_yaw) const;
+
+        // get_object_space_transform does not return any world space transforms and does not escape the node's asset inherited coordinate system!
+        // The only purpose this function can serve is within **the same** mesh's object space derived from the same asset! Cannot be used with other nodes!
+        // Like if you wanted to move a hat around already on the model.
+        [[nodiscard]] std::array<float, 16> get_object_space_transform() const;
+
+        // get_world_space_transform returns the asset's representation in the world after all object space transforms have been applied, from asset to rosy's
+        // world space coordinate system and then any world space transforms
         [[nodiscard]] std::array<float, 16> get_world_space_transform() const;
+
+       
+        [[nodiscard]] std::array<float, 3> get_world_space_position() const;
+
         void update_object_space_parent_transform(const std::array<float, 16>& new_parent_transform) const;
         void populate_graph(std::vector<graphics_object>& graph) const;
         void debug();

--- a/src/Engine/Node.h
+++ b/src/Engine/Node.h
@@ -23,7 +23,6 @@ namespace rosy
         std::vector<graphics_object> graphics_objects;
         std::string name{};
         std::vector<node*> children;
-        node_bounds world_space_bounds{};
 
         [[nodiscard]] result init(
             log* new_log,
@@ -38,6 +37,7 @@ namespace rosy
         void set_world_space_translate(const std::array<float, 3>& new_world_space_translate) const;
         void set_world_space_scale(const float new_world_space_scale) const;
         void set_world_space_yaw(float new_world_space_yaw) const;
+        void set_object_space_bounds(node_bounds new_object_space_bounds) const;
 
         // get_object_space_transform does not return any world space transforms and does not escape the node's asset inherited coordinate system!
         // The only purpose this function can serve is within **the same** mesh's object space derived from the same asset! Cannot be used with other nodes!
@@ -50,6 +50,9 @@ namespace rosy
 
         // get_to_object_space_transform this returns the matrix required to take something from world space to this object's space. 
         [[nodiscard]] std::array<float, 16> get_to_object_space_transform() const;
+
+        // get_world_space_bounds this returns the world space bounds that this object fills in world space.
+        [[nodiscard]] node_bounds get_world_space_bounds() const;
 
        
         [[nodiscard]] std::array<float, 3> get_world_space_position() const;

--- a/src/Engine/Node.h
+++ b/src/Engine/Node.h
@@ -27,6 +27,7 @@ namespace rosy
 
         [[nodiscard]] result init(
             log* new_log,
+            bool is_world_node,
             const std::array<float, 16>& coordinate_space,
             const std::array<float, 16>& new_object_space_parent_transform,
             const std::array<float, 16>& new_object_space_transform,

--- a/src/Engine/Node.h
+++ b/src/Engine/Node.h
@@ -23,7 +23,7 @@ namespace rosy
         std::vector<graphics_object> graphics_objects;
         std::string name{};
         std::vector<node*> children;
-        node_bounds bounds{};
+        node_bounds world_space_bounds{};
 
         [[nodiscard]] result init(
             log* new_log,
@@ -47,6 +47,9 @@ namespace rosy
         // get_world_space_transform returns the asset's representation in the world after all object space transforms have been applied, from asset to rosy's
         // world space coordinate system and then any world space transforms
         [[nodiscard]] std::array<float, 16> get_world_space_transform() const;
+
+        // get_to_object_space_transform this returns the matrix required to take something from world space to this object's space. 
+        [[nodiscard]] std::array<float, 16> get_to_object_space_transform() const;
 
        
         [[nodiscard]] std::array<float, 3> get_world_space_position() const;

--- a/src/Engine/Node.h
+++ b/src/Engine/Node.h
@@ -54,7 +54,7 @@ namespace rosy
         // get_world_space_bounds this returns the world space bounds that this object fills in world space.
         [[nodiscard]] node_bounds get_world_space_bounds() const;
 
-       
+
         [[nodiscard]] std::array<float, 3> get_world_space_position() const;
 
         void update_object_space_parent_transform(const std::array<float, 16>& new_parent_transform) const;

--- a/src/Engine/Node.h
+++ b/src/Engine/Node.h
@@ -23,42 +23,22 @@ namespace rosy
         std::vector<graphics_object> graphics_objects;
         std::string name{};
         std::vector<node*> children;
-        std::array<float, 16> parent_transform{
-            1.f, 0.f, 0.f, 0.f,
-            0.f, 1.f, 0.f, 0.f,
-            0.f, 0.f, 1.f, 0.f,
-            0.f, 0.f, 0.f, 1.f,
-        };
-        std::array<float, 16> transform{
-            1.f, 0.f, 0.f, 0.f,
-            0.f, 1.f, 0.f, 0.f,
-            0.f, 0.f, 1.f, 0.f,
-            0.f, 0.f, 0.f, 1.f,
-        };
-        std::array<float, 16> normal_transform{
-            1.f, 0.f, 0.f, 0.f,
-            0.f, 1.f, 0.f, 0.f,
-            0.f, 0.f, 1.f, 0.f,
-            0.f, 0.f, 0.f, 1.f,
-        };
-        std::array<float, 16> object_space_transform{
-            1.f, 0.f, 0.f, 0.f,
-            0.f, 1.f, 0.f, 0.f,
-            0.f, 0.f, 1.f, 0.f,
-            0.f, 0.f, 0.f, 1.f,
-        };
-        std::array<float, 4> position{};
-        std::array<float, 3> world_translate{};
-        float world_scale{1.f};
-        float world_yaw{0.f};
         node_bounds bounds{};
 
-        [[nodiscard]] result init(log* new_log, const std::array<float, 16>& new_transform, const std::array<float, 16>& new_parent_transform,
-                                  const std::array<float, 3> new_world_translate, float new_world_scale, float new_world_yaw);
+        [[nodiscard]] result init(
+            log* new_log,
+            const std::array<float, 16>& coordinate_space,
+            const std::array<float, 16>& new_object_space_parent_transform,
+            const std::array<float, 16>& new_object_space_transform,
+            const std::array<float, 3> new_world_translate,
+            float new_world_scale,
+            float new_world_yaw);
         void deinit();
-        [[nodiscard]] result set_position(const std::array<float, 3>& new_position);
-        [[nodiscard]] result update_transform(const std::array<float, 16>& new_parent_transform);
-        void update_parent_transform(const std::array<float, 16>& new_parent_transform);
+        void set_world_space_translate(const std::array<float, 3>& new_world_space_translate) const;
+        void set_world_space_scale(const float new_world_space_scale) const;
+        void set_world_space_yaw(float new_world_space_yaw) const;
+        [[nodiscard]] std::array<float, 16> get_world_space_transform() const;
+        void update_object_space_parent_transform(const std::array<float, 16>& new_parent_transform) const;
         void populate_graph(std::vector<graphics_object>& graph) const;
         void debug();
     };

--- a/src/Engine/Types.h
+++ b/src/Engine/Types.h
@@ -136,6 +136,7 @@ namespace rosy
         bool flip_tangent_y{false};
         bool flip_tangent_z{false};
         bool flip_tangent_w{false};
+        bool inverse_bnt{false};
     };
 
     struct light_debug_state

--- a/src/Engine/Types.h
+++ b/src/Engine/Types.h
@@ -150,7 +150,7 @@ namespace rosy
 
     struct draw_config_state
     {
-        bool reverse_winding_order_enabled{true};
+        bool reverse_winding_order_enabled{false};
         bool cull_enabled{false};
         bool wire_enabled{false};
         bool thick_wire_lines{false};

--- a/src/Engine/Types.h
+++ b/src/Engine/Types.h
@@ -51,7 +51,7 @@ namespace rosy
         std::vector<surface_graphics_data> surface_data{};
         std::array<float, 16> transform{};
         std::array<float, 16> normal_transform{};
-        std::array<float, 16> object_space_transform{};
+        std::array<float, 16> to_object_space_transform{};
     };
 
     struct graphics_object_update

--- a/src/Engine/Types.h
+++ b/src/Engine/Types.h
@@ -50,8 +50,8 @@ namespace rosy
         size_t index{0};
         std::vector<surface_graphics_data> surface_data{};
         std::array<float, 16> transform{};
-        std::array<float, 16> normal_transform{};
         std::array<float, 16> to_object_space_transform{};
+        std::array<float, 9> normal_transform{};
     };
 
     struct graphics_object_update

--- a/src/Engine/Types.h
+++ b/src/Engine/Types.h
@@ -123,7 +123,9 @@ namespace rosy
     struct light_read_write_state
     {
         std::array<float, 4> sunlight{};
+        std::array<float, 4> sunlight_color{};
         bool depth_bias_enabled{false};
+        float ambient_light{0.f};
         float depth_bias_constant{0.f};
         float depth_bias_clamp{0.f};
         float depth_bias_slope_factor{0.f};
@@ -158,7 +160,7 @@ namespace rosy
 
     struct fragment_config_state
     {
-        int output{0}; // 0 normal, 1 normals, 2 tangent, 3 light
+        int output{0}; // 0 default, 1 normals, 2 tangent, 3 light, 4 view 5 vertex colors
         bool light_enabled{false};
         bool tangent_space_enabled{false};
         bool shadows_enabled{false};

--- a/src/Engine/Types.h
+++ b/src/Engine/Types.h
@@ -162,6 +162,7 @@ namespace rosy
         bool light_enabled{false};
         bool tangent_space_enabled{false};
         bool shadows_enabled{false};
+        bool normal_maps_enabled{false};
     };
 
     struct mob_state

--- a/src/Packager/Asset.cpp
+++ b/src/Packager/Asset.cpp
@@ -21,9 +21,9 @@ using namespace rosy_packager;
 //       // index 0 - num nodes -> a std::vector<uint32_t> of node indices
 // 6. Per Node
 // 6a. Node size layout: std::array<size_t, 3>
-//       // index 0 - num custom_translate -> always 1 to represent a single std::array<float, 3>
-//       // index 1 - num custom_uniform_scale -> always 1 to represent a single float
-//       // index 2 - num custom_yaw -> always 1 to represent a single float
+//       // index 0 - num world_translate -> always 1 to represent a single std::array<float, 3>
+//       // index 1 - num world_scale -> always 1 to represent a single float
+//       // index 2 - num world_yaw -> always 1 to represent a single float
 //       // index 3 - num transforms -> always 1 to represent a single std::array<float, 16>
 //       // index 4 -> num mesh ids -> always 1 to represent a single uint32_t
 //       // index 5 -> num child_nodes -> a std::vector<uint32_t> to represent child node indices
@@ -168,9 +168,9 @@ rosy::result asset::write(const rosy::log* l)
     // WRITE ALL NODES ONE AT A TIME
 
     for (const auto& [
-             custom_translate,
-             custom_uniform_scale,
-             custom_yaw,
+             world_translate,
+             world_scale,
+             world_yaw,
              transform,
              mesh_id,
              child_nodes,
@@ -178,9 +178,9 @@ rosy::result asset::write(const rosy::log* l)
     {
         // WRITE ONE NODE SIZE
 
-        constexpr size_t num_custom_translate{1};
-        constexpr size_t num_custom_uniform_scale{1};
-        constexpr size_t num_custom_yaw{1};
+        constexpr size_t num_world_translate{1};
+        constexpr size_t num_world_scale{1};
+        constexpr size_t num_world_yaw{1};
         constexpr size_t num_transforms{1};
         constexpr size_t num_mesh_ids{1};
 
@@ -188,7 +188,7 @@ rosy::result asset::write(const rosy::log* l)
             const size_t num_child_nodes{child_nodes.size()};
             const size_t num_name_chars{node_name_chars.size()};
             constexpr size_t lookup_sizes = 1;
-            const std::array<size_t, 7> node_sizes{num_custom_translate, num_custom_uniform_scale, num_custom_yaw, num_transforms, num_mesh_ids, num_child_nodes, num_name_chars};
+            const std::array<size_t, 7> node_sizes{num_world_translate, num_world_scale, num_world_yaw, num_transforms, num_mesh_ids, num_child_nodes, num_name_chars};
             size_t res = fwrite(&node_sizes, sizeof(node_sizes), lookup_sizes, stream);
             if (res != lookup_sizes)
             {
@@ -196,44 +196,44 @@ rosy::result asset::write(const rosy::log* l)
                 return rosy::result::write_failed;
             }
             l->debug(std::format(
-                "wrote {} sizes, num_custom_translate: {}, num_custom_uniform_scale: {}, num_custom_yaw: {}, num_transforms: {} num_mesh_ids: {}, num_child_nodes: {},  num_name_chars: {}",
-                res, num_custom_translate, num_custom_uniform_scale, num_custom_yaw, num_transforms, num_mesh_ids, num_child_nodes, num_name_chars));
+                "wrote {} sizes, num_world_translate: {}, num_world_scale: {}, num_world_yaw: {}, num_transforms: {} num_mesh_ids: {}, num_child_nodes: {},  num_name_chars: {}",
+                res, num_world_translate, num_world_scale, num_world_yaw, num_transforms, num_mesh_ids, num_child_nodes, num_name_chars));
         }
 
-        // WRITE ONE NODE CUSTOM_TRANSLATE
+        // WRITE ONE NODE world_translate
 
         {
-            size_t res = fwrite(&custom_translate, sizeof(custom_translate), num_custom_translate, stream);
-            if (res != num_custom_translate)
+            size_t res = fwrite(&world_translate, sizeof(world_translate), num_world_translate, stream);
+            if (res != num_world_translate)
             {
-                l->error(std::format("failed to write {}/{} node custom_translate", res, num_custom_translate));
+                l->error(std::format("failed to write {}/{} node world_translate", res, num_world_translate));
                 return rosy::result::write_failed;
             }
-            l->debug(std::format("wrote {} node custom_translate", res));
+            l->debug(std::format("wrote {} node world_translate", res));
         }
 
-        // WRITE ONE NODE CUSTOM_UNIFORM_SCALE
+        // WRITE ONE NODE world_scale
 
         {
-            size_t res = fwrite(&custom_uniform_scale, sizeof(custom_uniform_scale), num_custom_uniform_scale, stream);
-            if (res != num_custom_uniform_scale)
+            size_t res = fwrite(&world_scale, sizeof(world_scale), num_world_scale, stream);
+            if (res != num_world_scale)
             {
-                l->error(std::format("failed to write {}/{} node custom_uniform_scale", res, num_custom_uniform_scale));
+                l->error(std::format("failed to write {}/{} node world_scale", res, num_world_scale));
                 return rosy::result::write_failed;
             }
-            l->debug(std::format("wrote {} node custom_uniform_scale", res));
+            l->debug(std::format("wrote {} node world_scale", res));
         }
 
-        // WRITE ONE NODE CUSTOM_CUSTOM_YAW
+        // WRITE ONE NODE CUSTOM_world_yaw
 
         {
-            size_t res = fwrite(&custom_yaw, sizeof(custom_yaw), num_custom_yaw, stream);
-            if (res != num_custom_yaw)
+            size_t res = fwrite(&world_yaw, sizeof(world_yaw), num_world_yaw, stream);
+            if (res != num_world_yaw)
             {
-                l->error(std::format("failed to write {}/{} node custom_yaw", res, num_custom_yaw));
+                l->error(std::format("failed to write {}/{} node world_yaw", res, num_world_yaw));
                 return rosy::result::write_failed;
             }
-            l->debug(std::format("wrote {} node custom_yaw", res));
+            l->debug(std::format("wrote {} node world_yaw", res));
         }
 
         // WRITE ONE NODE TRANSFORM
@@ -559,9 +559,9 @@ rosy::result asset::read(rosy::log* l)
 
         // READ ONE NODE SIZE
 
-        size_t num_custom_translate{0};
-        size_t num_custom_uniform_scale{0};
-        size_t num_custom_yaw{0};
+        size_t num_world_translate{0};
+        size_t num_world_scale{0};
+        size_t num_world_yaw{0};
         size_t num_transforms{0};
         size_t num_mesh_ids{0};
         size_t num_child_nodes{0};
@@ -575,9 +575,9 @@ rosy::result asset::read(rosy::log* l)
                 l->error(std::format("failed to read {}/{} node_sizes", res, lookup_sizes));
                 return rosy::result::read_failed;
             }
-            num_custom_translate = node_sizes[0];
-            num_custom_uniform_scale = node_sizes[1];
-            num_custom_yaw = node_sizes[2];
+            num_world_translate = node_sizes[0];
+            num_world_scale = node_sizes[1];
+            num_world_yaw = node_sizes[2];
             num_transforms = node_sizes[3];
             num_mesh_ids = node_sizes[4];
             num_child_nodes = node_sizes[5];
@@ -585,9 +585,9 @@ rosy::result asset::read(rosy::log* l)
             l->debug(std::format(
                 "read {} sizes, num_transforms: {} num_mesh_ids: {} num_child_nodes: {} num_node_name_chars: {}",
                 res, num_transforms, num_mesh_ids, num_child_nodes, num_node_name_chars));
-            assert(num_custom_translate == 1);
-            assert(num_custom_uniform_scale == 1);
-            assert(num_custom_yaw == 1);
+            assert(num_world_translate == 1);
+            assert(num_world_scale == 1);
+            assert(num_world_yaw == 1);
             assert(num_transforms == 1);
             assert(num_mesh_ids == 1);
         }
@@ -595,40 +595,40 @@ rosy::result asset::read(rosy::log* l)
         n.child_nodes.resize(num_child_nodes);
         n.name.resize(num_node_name_chars);
 
-        // READ ONE NODE CUSTOM_TRANSLATE
+        // READ ONE NODE world_translate
 
         {
-            size_t res = fread(&n.custom_translate, sizeof(std::array<float, 3>), num_custom_translate, stream);
-            if (res != num_custom_translate)
+            size_t res = fread(&n.world_translate, sizeof(std::array<float, 3>), num_world_translate, stream);
+            if (res != num_world_translate)
             {
-                l->error(std::format("failed to read {}/{} node custom_translate", res, num_custom_translate));
+                l->error(std::format("failed to read {}/{} node world_translate", res, num_world_translate));
                 return rosy::result::read_failed;
             }
-            l->debug(std::format("read {} node custom_translate", res));
+            l->debug(std::format("read {} node world_translate", res));
         }
 
-        // READ ONE NODE CUSTOM_UNIFORM_SCALE
+        // READ ONE NODE world_scale
 
         {
-            size_t res = fread(&n.custom_uniform_scale, sizeof(float), num_custom_uniform_scale, stream);
-            if (res != num_custom_uniform_scale)
+            size_t res = fread(&n.world_scale, sizeof(float), num_world_scale, stream);
+            if (res != num_world_scale)
             {
-                l->error(std::format("failed to read {}/{} node custom_uniform_scale", res, num_custom_uniform_scale));
+                l->error(std::format("failed to read {}/{} node world_scale", res, num_world_scale));
                 return rosy::result::read_failed;
             }
-            l->debug(std::format("read {} node custom_uniform_scale", res));
+            l->debug(std::format("read {} node world_scale", res));
         }
 
-        // READ ONE NODE CUSTOM_YAW
+        // READ ONE NODE world_yaw
 
         {
-            size_t res = fread(&n.custom_yaw, sizeof(float), num_custom_yaw, stream);
-            if (res != num_custom_yaw)
+            size_t res = fread(&n.world_yaw, sizeof(float), num_world_yaw, stream);
+            if (res != num_world_yaw)
             {
-                l->error(std::format("failed to read {}/{} node custom_yaw", res, num_custom_yaw));
+                l->error(std::format("failed to read {}/{} node world_yaw", res, num_world_yaw));
                 return rosy::result::read_failed;
             }
-            l->debug(std::format("read {} node custom_yaw", res));
+            l->debug(std::format("read {} node world_yaw", res));
         }
 
         // READ ONE NODE TRANSFORM

--- a/src/Packager/Asset.cpp
+++ b/src/Packager/Asset.cpp
@@ -179,6 +179,7 @@ rosy::result asset::write(const rosy::log* l)
              world_translate,
              world_scale,
              world_yaw,
+             coordinate_transform,
              transform,
              mesh_id,
              child_nodes,

--- a/src/Packager/Asset.cpp
+++ b/src/Packager/Asset.cpp
@@ -60,6 +60,7 @@ rosy::result asset::write(const rosy::log* l)
             .magic = rosy_format,
             .version = current_version,
             .endianness = 1, // for std::endian::little
+            .coordinate_system = asset_coordinate_system,
             .root_scene = root_scene,
         };
         size_t res = fwrite(&header, sizeof(header), num_headers, stream);
@@ -69,6 +70,13 @@ rosy::result asset::write(const rosy::log* l)
             return rosy::result::write_failed;
         }
         l->debug(std::format("wrote {} headers", res));
+        l->info(std::format(
+            "coordinate system: (\n{:.2f},{:.2f},{:.2f},{:.2f},\n{:.2f},{:.2f},{:.2f},{:.2f},\n{:.2f},{:.2f},{:.2f},{:.2f},\n{:.2f},{:.2f},{:.2f},{:.2f},\n)",
+            asset_coordinate_system[0], asset_coordinate_system[1], asset_coordinate_system[2], asset_coordinate_system[3],
+            asset_coordinate_system[4], asset_coordinate_system[5], asset_coordinate_system[6], asset_coordinate_system[7],
+            asset_coordinate_system[8], asset_coordinate_system[9], asset_coordinate_system[10], asset_coordinate_system[11],
+            asset_coordinate_system[12], asset_coordinate_system[13], asset_coordinate_system[14], asset_coordinate_system[15]
+        ));
     }
 
     // WRITE GLTF SIZES FOR ASSET RESOURCES
@@ -421,6 +429,7 @@ rosy::result asset::read(rosy::log* l)
             .magic = 0,
             .version = 0,
             .endianness = 0,
+            .coordinate_system = {},
             .root_scene = 0,
         };
         size_t res = fread(&header, sizeof(header), num_headers, stream);
@@ -436,22 +445,27 @@ rosy::result asset::read(rosy::log* l)
         }
         if (header.version != current_version)
         {
-            l->error(std::format("failed to read, version mismatch file is version {} current version is {}",
-                                 header.version, current_version));
+            l->error(std::format("failed to read, version mismatch file is version {} current version is {}", header.version, current_version));
             return rosy::result::read_failed;
         }
         constexpr uint32_t is_little_endian = 1; // This always true: std::endian::native == std::endian::little 
         // NOLINT(clang-diagnostic-unreachable-code)
         if (header.endianness != is_little_endian)
         {
-            l->error(std::format("failed to read, endianness mismatch file is {} system is {}", header.endianness,
-                                 is_little_endian));
+            l->error(std::format("failed to read, endianness mismatch file is {} system is {}", header.endianness, is_little_endian));
             return rosy::result::read_failed;
         }
+        asset_coordinate_system = header.coordinate_system;
         root_scene = header.root_scene;
         l->debug(std::format("read {} headers", res));
-        l->debug(std::format("format version: {} is little endian: {} root scene: {}",
-                             header.version, is_little_endian, root_scene));
+        l->debug(std::format("format version: {} is little endian: {} root scene: {}", header.version, is_little_endian, root_scene));
+        l->info(std::format(
+            "coordinate system: (\n{:.2f},{:.2f},{:.2f},{:.2f},\n{:.2f},{:.2f},{:.2f},{:.2f},\n{:.2f},{:.2f},{:.2f},{:.2f},\n{:.2f},{:.2f},{:.2f},{:.2f},\n)",
+            asset_coordinate_system[0], asset_coordinate_system[1], asset_coordinate_system[2], asset_coordinate_system[3],
+            asset_coordinate_system[4], asset_coordinate_system[5], asset_coordinate_system[6], asset_coordinate_system[7],
+            asset_coordinate_system[8], asset_coordinate_system[9], asset_coordinate_system[10], asset_coordinate_system[11],
+            asset_coordinate_system[12], asset_coordinate_system[13], asset_coordinate_system[14], asset_coordinate_system[15]
+        ));
     }
 
     // WRITE GLTF SIZES FOR ALL ASSET RESOURCES

--- a/src/Packager/Asset.cpp
+++ b/src/Packager/Asset.cpp
@@ -180,6 +180,7 @@ rosy::result asset::write(const rosy::log* l)
              world_scale,
              world_yaw,
              coordinate_transform,
+             is_world_node,
              transform,
              mesh_id,
              child_nodes,

--- a/src/Packager/Asset.h
+++ b/src/Packager/Asset.h
@@ -15,6 +15,12 @@ namespace rosy_packager
         uint32_t magic{0};
         uint32_t version{0};
         uint32_t endianness{0};
+        std::array<float, 16> coordinate_system{
+            1.f, 0.f, 0.f, 0.f,
+            0.f, 1.f, 0.f, 0.f,
+            0.f, 0.f, 1.f, 0.f,
+            0.f, 0.f, 0.f, 1.f,
+        };
         uint32_t root_scene{0};
     };
 

--- a/src/Packager/Asset.h
+++ b/src/Packager/Asset.h
@@ -51,9 +51,9 @@ namespace rosy_packager
 
     struct node
     {
-        std::array<float, 3> custom_translate{0.f, 0.f, 0.f};
-        float custom_uniform_scale{1.f};
-        float custom_yaw{0.f};
+        std::array<float, 3> world_translate{0.f, 0.f, 0.f};
+        float world_scale{1.f};
+        float world_yaw{0.f};
         std::array<float, 16> transform{
             1.f, 0.f, 0.f, 0.f,
             0.f, 1.f, 0.f, 0.f,
@@ -113,6 +113,12 @@ namespace rosy_packager
         std::vector<image> images;
         std::vector<mesh> meshes;
         std::vector<shader> shaders;
+        std::array<float, 16> asset_coordinate_system{
+            1.f, 0.f, 0.f, 0.f,
+            0.f, 1.f, 0.f, 0.f,
+            0.f, 0.f, 1.f, 0.f,
+            0.f, 0.f, 0.f, 1.f,
+        };
         uint32_t root_scene{0};
 
         rosy::result write(const rosy::log* l);

--- a/src/Packager/Asset.h
+++ b/src/Packager/Asset.h
@@ -62,6 +62,9 @@ namespace rosy_packager
         std::array<float, 3> world_translate{0.f, 0.f, 0.f};
         float world_scale{1.f};
         float world_yaw{0.f};
+        // Nodes need a coordinate system because they can be combined from different asset systems at runtime.
+        // Not written to file! It is intentionally by default a zero matrix to identify it easily as not valid.
+        std::array<float, 16> coordinate_system{};
         std::array<float, 16> transform{
             1.f, 0.f, 0.f, 0.f,
             0.f, 1.f, 0.f, 0.f,

--- a/src/Packager/Asset.h
+++ b/src/Packager/Asset.h
@@ -36,6 +36,8 @@ namespace rosy_packager
         float alpha_cutoff{0.f};
         uint32_t normal_image_index{UINT32_MAX}; // UINT32_MAX == not present
         uint32_t normal_sampler_index{UINT32_MAX}; // UINT32_MAX == not present
+        uint32_t metallic_image_index{ UINT32_MAX }; // UINT32_MAX == not present
+        uint32_t metallic_sampler_index{ UINT32_MAX }; // UINT32_MAX == not present
     };
 
     struct sampler
@@ -95,6 +97,7 @@ namespace rosy_packager
     // image_type is effectively an enum
     constexpr uint32_t image_type_color{0};
     constexpr uint32_t image_type_normal_map{1};
+    constexpr uint32_t image_type_metallic_roughness{2};
 
     // More image types as needed will be added.
     struct image

--- a/src/Packager/Asset.h
+++ b/src/Packager/Asset.h
@@ -36,8 +36,8 @@ namespace rosy_packager
         float alpha_cutoff{0.f};
         uint32_t normal_image_index{UINT32_MAX}; // UINT32_MAX == not present
         uint32_t normal_sampler_index{UINT32_MAX}; // UINT32_MAX == not present
-        uint32_t metallic_image_index{ UINT32_MAX }; // UINT32_MAX == not present
-        uint32_t metallic_sampler_index{ UINT32_MAX }; // UINT32_MAX == not present
+        uint32_t metallic_image_index{UINT32_MAX}; // UINT32_MAX == not present
+        uint32_t metallic_sampler_index{UINT32_MAX}; // UINT32_MAX == not present
     };
 
     struct sampler
@@ -65,6 +65,9 @@ namespace rosy_packager
         // Nodes need a coordinate system because they can be combined from different asset systems at runtime.
         // Not written to file! It is intentionally by default a zero matrix to identify it easily as not valid.
         std::array<float, 16> coordinate_system{};
+        //  is_world_node another node property that not written to the file format and helps distinguish nodes
+        // that are independent world nodes from nodes that are ancestors of world nodes.
+        bool is_world_node{false};
         std::array<float, 16> transform{
             1.f, 0.f, 0.f, 0.f,
             0.f, 1.f, 0.f, 0.f,

--- a/src/Packager/Gltf.cpp
+++ b/src/Packager/Gltf.cpp
@@ -47,7 +47,12 @@ namespace
 rosy::result gltf::import(rosy::log* l)
 {
     const std::filesystem::path file_path{source_path};
-
+    gltf_asset.asset_coordinate_system = {
+           -1.f, 0.f, 0.f, 0.f,
+           0.f, 1.f, 0.f, 0.f,
+           0.f, 0.f, 1.f, 0.f,
+           0.f, 0.f, 0.f, 1.f,
+    };
     constexpr auto gltf_options = fastgltf::Options::DontRequireValidAssetMember | fastgltf::Options::AllowDouble |
         fastgltf::Options::LoadExternalBuffers | fastgltf::Options::DecomposeNodeMatrices;
 

--- a/src/Packager/Gltf.cpp
+++ b/src/Packager/Gltf.cpp
@@ -96,6 +96,7 @@ rosy::result gltf::import(rosy::log* l)
     // MATERIALS
 
     std::vector<std::tuple<uint32_t, uint32_t>> normal_map_images;
+    std::vector<std::tuple<uint32_t, uint32_t>> metallic_images;
     std::vector<std::tuple<uint32_t, uint32_t>> color_images;
     {
         for (fastgltf::Material& mat : gltf.materials)
@@ -119,6 +120,26 @@ rosy::result gltf::import(rosy::log* l)
                 else
                 {
                     m.color_sampler_index = UINT32_MAX;
+                }
+            }
+            if (mat.pbrData.metallicRoughnessTexture.has_value())
+            {
+                if (gltf.textures[mat.pbrData.metallicRoughnessTexture.value().textureIndex].imageIndex.has_value())
+                {
+                    m.metallic_image_index = static_cast<uint32_t>(gltf.textures[mat.pbrData.metallicRoughnessTexture.value().textureIndex].imageIndex.value());
+                    metallic_images.emplace_back(m.metallic_image_index, static_cast<uint32_t>(color_images.size()));
+                }
+                else
+                {
+                    m.metallic_image_index = UINT32_MAX;
+                }
+                if (gltf.textures[mat.pbrData.metallicRoughnessTexture.value().textureIndex].samplerIndex.has_value())
+                {
+                    m.metallic_sampler_index = static_cast<uint32_t>(gltf.textures[mat.pbrData.metallicRoughnessTexture.value().textureIndex].samplerIndex.value());
+                }
+                else
+                {
+                    m.metallic_sampler_index = UINT32_MAX;
                 }
             }
             if (mat.normalTexture.has_value())
@@ -199,6 +220,91 @@ rosy::result gltf::import(rosy::log* l)
                     image.width(), image.height(), image.depth(), static_cast<uint8_t>(image.type()), input_filename));
 
                 nvtt::Context context(true); // Enable CUDA
+
+                nvtt::CompressionOptions compression_options;
+                compression_options.setFormat(nvtt::Format_BC7);
+
+                img_path.replace_filename(std::format("{}.dds", gltf_img.name));
+                std::string output_filename = img_path.string();
+                nvtt::OutputOptions output_options;
+                output_options.setFileName(output_filename.c_str());
+
+                int num_mipmaps = image.countMipmaps();
+
+                l->info(std::format("num mip maps are {} for {}", num_mipmaps, input_filename));
+
+                if (!context.outputHeader(image, num_mipmaps, compression_options, output_options))
+                {
+                    l->error(std::format("Writing dds headers failed for  {}", input_filename));
+                    return rosy::result::error;
+                }
+
+                for (int mip = 0; mip < num_mipmaps; mip++)
+                {
+                    // Compress this image and write its data.
+                    if (!context.compress(image, 0 /* face */, mip, compression_options, output_options))
+                    {
+                        l->error(std::format("Compressing and writing the dds file failed for  {}", input_filename));
+                        return rosy::result::error;
+                    }
+
+                    if (mip == num_mipmaps - 1)
+                    {
+                        break;
+                    }
+
+                    image.toLinearFromSrgb();
+                    image.premultiplyAlpha();
+
+                    image.buildNextMipmap(nvtt::MipmapFilter_Box);
+
+                    image.demultiplyAlpha();
+                    image.toSrgb();
+                }
+            }
+        }
+    }
+    {
+        std::ranges::sort(metallic_images);
+        auto last = std::ranges::unique(metallic_images).begin();
+        metallic_images.erase(last, metallic_images.end());
+        l->info(std::format("num metallic_images {}", metallic_images.size()));
+        for (const auto& [gltf_index, rosy_index] : metallic_images)
+        {
+            // Declare it as a metallic image
+            gltf_asset.images[gltf_index].image_type = image_type_metallic_roughness;
+            const auto& gltf_img = gltf.images[gltf_index];
+            auto& img_path = pre_rename_image_paths[rosy_index];
+            l->info(std::format("{} is a gltf_img metallic image", gltf_img.name));
+            l->info(std::format("{} is an image_path metallic image", img_path.string()));
+
+            if (!std::holds_alternative<fastgltf::sources::URI>(gltf_img.data))
+            {
+                l->error(std::format("{} is not a URI datasource", gltf_img.name));
+                return rosy::result::error;
+            }
+
+            const fastgltf::sources::URI uri_ds = std::get<fastgltf::sources::URI>(gltf_img.data);
+            l->info(std::format("metallic image uri is: {}", uri_ds.uri.string()));
+
+            std::filesystem::path source_img_path{ gltf_asset.asset_path };
+            source_img_path.replace_filename(uri_ds.uri.string());
+            l->info(std::format("source_img_path for metallic image is: {}", source_img_path.string()));
+
+            {
+                std::string input_filename{ source_img_path.string() };
+
+                nvtt::Surface image;
+                if (!image.load(input_filename.c_str()))
+                {
+                    l->error(std::format("Failed to load file  for  {}", input_filename));
+                    return rosy::result::error;
+                }
+
+                l->info(std::format("image data is width: {} height: {} depth: {} type: {} for ",
+                    image.width(), image.height(), image.depth(), static_cast<uint8_t>(image.type()), input_filename));
+
+                nvtt::Context context(true);
 
                 nvtt::CompressionOptions compression_options;
                 compression_options.setFormat(nvtt::Format_BC7);

--- a/src/shaders/basic.slang
+++ b/src/shaders/basic.slang
@@ -151,13 +151,15 @@ Fragment fragmentMain(BasicVertex basicVertex: BasicVertex, CSM csm: CSM, float4
     uint nsi = md.normal_sampler_index;
 
     float3 lightNormal = normalize(basicVertex.normal);
+    float3 lightDir = normalize(basicVertex.lightDir);
 
     if (sd.normalMapsEnabled == 1 && validDescriptorIndex(nti))
     {
+        lightDir = normalize(-basicVertex.lightDir);
         texture2D normalMap = imageTexture[NonUniformResourceIndex(nti)];
         SamplerState normalSampler = imageSampler[NonUniformResourceIndex(nsi)];
 
-        lightNormal = normalMap.Sample(normalSampler, basicVertex.textureCoordinates).xyz;
+        lightNormal = normalMap.Sample(normalSampler, basicVertex.textureCoordinates).xyz * 2 - 1;
     }
 
     float4 outFragColor = md.color;
@@ -194,7 +196,7 @@ Fragment fragmentMain(BasicVertex basicVertex: BasicVertex, CSM csm: CSM, float4
     if (sd.lightEnabled > 0)
     {
         float3 V = normalize(basicVertex.viewDir);
-        float3 L = normalize(basicVertex.lightDir);
+        float3 L = lightDir;
         float3 N = lightNormal;
         float3 H = L + V;
 

--- a/src/shaders/basic.slang
+++ b/src/shaders/basic.slang
@@ -20,29 +20,23 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
     float4x4 worldMat = gd.transform;
     float4x4 normalMat = gd.normalTransform;
 
-    float4 object_space_camera = mul(gd.toObjectSpaceTransform, sd.cameraPosition);
-    float4 object_light_dir = mul(gd.toObjectSpaceTransform, float4(sd.sunlight.xyz, 0.f));
-
-    float4 vertPos = float4(v.position, 1.0);
-    float4 camPos = mul(mul(sd.view, worldMat), vertPos);
-
     float4x4 ndc_to_tc = { 0.5, 0, 0, 0.5, 0, 0.5, 0, 0.5, 0, 0, 1, 0, 0, 0, 0, 1 };
 
-    float3 light = object_light_dir.xyz - camPos.xyz;
+    float3 lightDir = sd.sunlight.xyz;
     float4 new_tangent = v.tangent;
 
     // flip lights
     if (sd.flipLights[0] == 1)
     {
-        light = light * float3(-1, 1, 1);
+        lightDir = lightDir * float3(-1, 1, 1);
     }
     if (sd.flipLights[1] == 1)
     {
-        light = light * float3(1, -1, 1);
+        lightDir = lightDir * float3(1, -1, 1);
     }
     if (sd.flipLights[2] == 1)
     {
-        light = light * float3(1, 1, -1);
+        lightDir = lightDir * float3(1, 1, -1);
     }
 
     // flip tangents
@@ -63,12 +57,6 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
         new_tangent = new_tangent * float4(1, 1, 1, -1);
     }
 
-    float3 normal = mul(normalMat, float4(v.normal, 1.f)).xyz;
-    float3 tangent = mul(normalMat, new_tangent).xyz;
-    float3 bitangent = normalize(cross(normal, tangent)) * new_tangent.w;
-
-    float3 view = normalize(-camPos.xyz);
-
     bool tangentSpaceEnabled = sd.tangentSpaceEnabled == 1;
     if (BasicPushConstants.md != nullptr)
     {
@@ -80,12 +68,24 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
         }
     }
 
+    float3 viewDir;
+
+    float3 normal = mul(normalMat, float4(v.normal, 1.f)).xyz;
+    float3 tangent = mul(normalMat, new_tangent).xyz;
+
     if (tangentSpaceEnabled)
     {
+        float3 bitangent = normalize(cross(normal, tangent)) * new_tangent.w;
         float3x3 toObjectLocal = float3x3(tangent, bitangent, normal);
-        view = mul(toObjectLocal, view);
-        light = mul(toObjectLocal, light);
+        float3 pos = mul(mul(sd.view, worldMat), float4(v.position, 1.0)).xyz;
+
+        lightDir = mul(toObjectLocal, lightDir - pos);
+        viewDir = mul(toObjectLocal, normalize(-pos));
+    } else {
+        viewDir = mul(mul(sd.view, worldMat), float4(v.position, 1.0)).xyz;
     }
+
+    float4 vertPos = float4(v.position, 1.0);
 
     BasicVertexStageOutput output;
     output.basicVertex.vertex = float4(v.position, 1.f);
@@ -93,8 +93,8 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
     output.basicVertex.worldNormal = mul(gd.normalTransform, float4(v.normal, 0.f)).xyz;
     output.basicVertex.color = v.color;
     output.basicVertex.tangent = tangent * v.tangent.w;
-    output.basicVertex.viewDir = view;
-    output.basicVertex.lightDir = light;
+    output.basicVertex.viewDir = viewDir;
+    output.basicVertex.lightDir = lightDir;
     output.basicVertex.textureCoordinates = v.textureCoordinates;
     output.csm.near = mul(mul(mul(ndc_to_tc, sd.shadowProjNear), worldMat), vertPos);
 
@@ -108,25 +108,33 @@ Fragment fragmentMain(BasicVertex basicVertex: BasicVertex, CSM csm: CSM, float4
 {
     SceneData sd = *BasicPushConstants.sd;
 
-    if (BasicPushConstants.md == nullptr)
+    if (sd.fragmentOutput == 5 || BasicPushConstants.md == nullptr)
     {
 
-        float3 V = normalize(basicVertex.viewDir);
-        float3 L = normalize(basicVertex.lightDir);
-        float3 N = normalize(basicVertex.normal);
-        float3 H = L + V;
+        if (sd.lightEnabled > 0)
+        {
+            float3 V = normalize(basicVertex.viewDir);
+            float3 L = normalize(basicVertex.lightDir);
+            float3 N = normalize(basicVertex.normal);
+            float3 H = L + V;
 
-        float cosTheta = dot(L, N);
-        float cosPhi = dot(H, N);
+            float cosTheta = dot(L, N);
+            float cosPhi = dot(H, N);
 
-        float3 ambientLight = sd.ambientColor.xyz;
-        float3 sunLight = sd.sunlightColor.xyz * max(cosTheta, 0.0);
+            float3 ambientLight = sd.ambientColor.xyz;
+            float3 sunLight = sd.sunlightColor.xyz * max(cosTheta, 0.0);
 
-        float4 outFragColor = basicVertex.color * float4(ambientLight * sunLight, 1.0);
+            float4 outFragColor = basicVertex.color * float4(ambientLight * sunLight, 1.0);
+
+            Fragment output;
+            output.color = outFragColor;
+            return output;
+        }
 
         Fragment output;
-        output.color = outFragColor;
+        output.color = basicVertex.color;
         return output;
+
     }
 
     BasicMaterialData md = *BasicPushConstants.md;
@@ -170,6 +178,8 @@ Fragment fragmentMain(BasicVertex basicVertex: BasicVertex, CSM csm: CSM, float4
         break;
     case 4:
         outFragColor = float4(normalize(basicVertex.viewDir) * 0.5 + 0.5, 1.f);
+        break;
+    default:
         break;
     }
 

--- a/src/shaders/basic.slang
+++ b/src/shaders/basic.slang
@@ -20,8 +20,8 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
     float4x4 worldMat = gd.transform;
     float4x4 normalMat = gd.normalTransform;
 
-    float4 object_space_camera = mul(gd.objectSpaceTransform, sd.cameraPosition);
-    float4 object_light_dir = mul(gd.objectSpaceTransform, float4(sd.sunlight.xyz, 0.f));
+    float4 object_space_camera = mul(gd.toObjectSpaceTransform, sd.cameraPosition);
+    float4 object_light_dir = mul(gd.toObjectSpaceTransform, float4(sd.sunlight.xyz, 0.f));
 
     float4 posWorld = float4(v.position, 1.0);
 

--- a/src/shaders/basic.slang
+++ b/src/shaders/basic.slang
@@ -18,7 +18,7 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
     BasicInputVertex v = *(BasicPushConstants.v + uiVertexId);
     BasicGraphicsData gd = *BasicPushConstants.gd;
     float4x4 worldMat = gd.transform;
-    float4x4 normalMat = gd.normalTransform;
+    float3x3 normalMat = gd.normalTransform;
 
     float4x4 ndc_to_tc = { 0.5, 0, 0, 0.5, 0, 0.5, 0, 0.5, 0, 0, 1, 0, 0, 0, 0, 1 };
 
@@ -70,8 +70,8 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
 
     float3 viewDir;
 
-    float3 normal = mul(normalMat, float4(v.normal, 1.f)).xyz;
-    float3 tangent = mul(normalMat, new_tangent).xyz;
+    float3 normal = normalize(mul(normalMat, v.normal));
+    float3 tangent = normalize(mul(normalMat, new_tangent.xyz));
 
     if (tangentSpaceEnabled)
     {
@@ -87,7 +87,7 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
         }
         float3 pos = mul(mul(sd.view, worldMat), float4(v.position, 1.0)).xyz;
 
-        lightDir = mul(toObjectLocal, lightDir - pos);
+        lightDir = mul(toObjectLocal, lightDir);
         viewDir = mul(toObjectLocal, normalize(-pos));
     } else {
         viewDir = mul(mul(sd.view, worldMat), float4(v.position, 1.0)).xyz;
@@ -98,7 +98,7 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
     BasicVertexStageOutput output;
     output.basicVertex.vertex = float4(v.position, 1.f);
     output.basicVertex.normal = normal;
-    output.basicVertex.worldNormal = mul(gd.normalTransform, float4(v.normal, 0.f)).xyz;
+    output.basicVertex.worldNormal = mul(gd.normalTransform, v.normal);
     output.basicVertex.color = v.color;
     output.basicVertex.tangent = tangent * v.tangent.w;
     output.basicVertex.viewDir = viewDir;

--- a/src/shaders/basic.slang
+++ b/src/shaders/basic.slang
@@ -76,7 +76,15 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
     if (tangentSpaceEnabled)
     {
         float3 bitangent = normalize(cross(normal, tangent)) * new_tangent.w;
+
         float3x3 toObjectLocal = float3x3(tangent, bitangent, normal);
+        if (sd.inverseBNT > 0) {
+            toObjectLocal = float3x3(
+                float3(tangent.x, bitangent.x, normal.x),
+                float3(tangent.y, bitangent.y, normal.y),
+                float3(tangent.z, bitangent.z, normal.z),
+            );
+        }
         float3 pos = mul(mul(sd.view, worldMat), float4(v.position, 1.0)).xyz;
 
         lightDir = mul(toObjectLocal, lightDir - pos);
@@ -142,7 +150,7 @@ Fragment fragmentMain(BasicVertex basicVertex: BasicVertex, CSM csm: CSM, float4
     uint nti = md.normal_texture_index;
     uint nsi = md.normal_sampler_index;
 
-    float3 lightNormal = basicVertex.normal;
+    float3 lightNormal = normalize(basicVertex.normal);
 
     if (sd.normalMapsEnabled == 1 && validDescriptorIndex(nti))
     {
@@ -206,8 +214,7 @@ Fragment fragmentMain(BasicVertex basicVertex: BasicVertex, CSM csm: CSM, float4
             shadowFactor = pcf(fragCoord, csm.near, shadowNearImage, shadowSampler);
         }
 
-        outFragColor =
-            max(outFragColor * float4(ambientLight, 1.f), outFragColor * float4(sunLight * shadowFactor, 1.0));
+        outFragColor = max(outFragColor * float4(ambientLight, 1.f), outFragColor * float4(sunLight * shadowFactor, 1.0));
     }
 
     Fragment output;

--- a/src/shaders/basic.slang
+++ b/src/shaders/basic.slang
@@ -23,11 +23,12 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
     float4 object_space_camera = mul(gd.toObjectSpaceTransform, sd.cameraPosition);
     float4 object_light_dir = mul(gd.toObjectSpaceTransform, float4(sd.sunlight.xyz, 0.f));
 
-    float4 posWorld = float4(v.position, 1.0);
+    float4 vertPos = float4(v.position, 1.0);
+    float4 camPos = mul(mul(sd.view, worldMat), vertPos);
 
     float4x4 ndc_to_tc = { 0.5, 0, 0, 0.5, 0, 0.5, 0, 0.5, 0, 0, 1, 0, 0, 0, 0, 1 };
 
-    float3 light = object_light_dir.xyz;
+    float3 light = object_light_dir.xyz - camPos.xyz;
     float4 new_tangent = v.tangent;
 
     // flip lights
@@ -62,11 +63,11 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
         new_tangent = new_tangent * float4(1, 1, 1, -1);
     }
 
-    float3 normal = v.normal;
-    float3 tangent = new_tangent.xyz;
-    float3 bitangent = cross(normal, tangent) * new_tangent.w;
+    float3 normal = mul(normalMat, float4(v.normal, 1.f)).xyz;
+    float3 tangent = mul(normalMat, new_tangent).xyz;
+    float3 bitangent = normalize(cross(normal, tangent)) * new_tangent.w;
 
-    float3 view = object_space_camera.xyz - v.position.xyz;
+    float3 view = normalize(-camPos.xyz);
 
     bool tangentSpaceEnabled = sd.tangentSpaceEnabled == 1;
     if (BasicPushConstants.md != nullptr)
@@ -81,8 +82,9 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
 
     if (tangentSpaceEnabled)
     {
-        view = float3(dot(tangent, view), dot(bitangent, view), dot(normal, view));
-        light = float3(dot(tangent, light), dot(bitangent, light), dot(normal, light));
+        float3x3 toObjectLocal = float3x3(tangent, bitangent, normal);
+        view = mul(toObjectLocal, view);
+        light = mul(toObjectLocal, light);
     }
 
     BasicVertexStageOutput output;
@@ -94,9 +96,9 @@ BasicVertexStageOutput vertexMain(uint uiVertexId: SV_VertexID)
     output.basicVertex.viewDir = view;
     output.basicVertex.lightDir = light;
     output.basicVertex.textureCoordinates = v.textureCoordinates;
-    output.csm.near = mul(mul(mul(ndc_to_tc, sd.shadowProjNear), worldMat), posWorld);
+    output.csm.near = mul(mul(mul(ndc_to_tc, sd.shadowProjNear), worldMat), vertPos);
 
-    output.sv_position = mul(mul(sd.viewproj, worldMat), posWorld);
+    output.sv_position = mul(mul(sd.viewproj, worldMat), vertPos);
 
     return output;
 }
@@ -134,7 +136,7 @@ Fragment fragmentMain(BasicVertex basicVertex: BasicVertex, CSM csm: CSM, float4
 
     float3 lightNormal = basicVertex.normal;
 
-    if (validDescriptorIndex(nti))
+    if (sd.normalMapsEnabled == 1 && validDescriptorIndex(nti))
     {
         texture2D normalMap = imageTexture[NonUniformResourceIndex(nti)];
         SamplerState normalSampler = imageSampler[NonUniformResourceIndex(nsi)];

--- a/src/shaders/data.slang
+++ b/src/shaders/data.slang
@@ -60,6 +60,7 @@ public struct SceneData
     public uint tangentSpaceEnabled;
     public uint shadowsEnabled;
     public uint normalMapsEnabled;
+    public uint inverseBNT;
 };
 
 public struct Fragment

--- a/src/shaders/data.slang
+++ b/src/shaders/data.slang
@@ -29,8 +29,8 @@ public struct BasicInputVertex {
 
 public struct BasicGraphicsData {
     public float4x4 transform;
-    public float4x4 normalTransform;
     public float4x4 toObjectSpaceTransform;
+    public float3x3 normalTransform;
 };
 
 public struct CSM

--- a/src/shaders/data.slang
+++ b/src/shaders/data.slang
@@ -59,6 +59,7 @@ public struct SceneData
     public uint lightEnabled;
     public uint tangentSpaceEnabled;
     public uint shadowsEnabled;
+    public uint normalMapsEnabled;
 };
 
 public struct Fragment

--- a/src/shaders/data.slang
+++ b/src/shaders/data.slang
@@ -76,6 +76,8 @@ public struct BasicMaterialData {
     public uint32_t color_sampler_index;
     public uint32_t normal_texture_index;
     public uint32_t normal_sampler_index;
+    public uint32_t metallic_texture_index;
+    public uint32_t metallic_sampler_index;
 };
 
 public struct BasicPushConstant {

--- a/src/shaders/data.slang
+++ b/src/shaders/data.slang
@@ -30,7 +30,7 @@ public struct BasicInputVertex {
 public struct BasicGraphicsData {
     public float4x4 transform;
     public float4x4 normalTransform;
-    public float4x4 objectSpaceTransform;
+    public float4x4 toObjectSpaceTransform;
 };
 
 public struct CSM


### PR DESCRIPTION
I had made major mistakes with mixing world space information with object space that led to a flipped axis and inverted rotations. I then built a big mess of fixes trying work around the problem instead of cleaning up my coordinate systems. This fixes all that. It also fixes a tangent space problem where I was not applying a transformation to take the normals from texture coordinate space 0 to 1 to NDC -1 to 1 coordinates.

There are still some minor tangent space issues I will need to fix I think with mikktspace and mesh optimization as a follow up. I can see some issues still in this photo:

![image](https://github.com/user-attachments/assets/92573443-0900-4f11-807f-ab386c76bb5b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced lighting controls in the UI with additional sliders and checkboxes for adjusting ambient light, sunlight color, and fragment configurations.
  - Improved material rendering with advanced support for normal maps and metallic roughness textures, delivering more realistic visuals.
  - Upgraded asset and scene transformation handling for more consistent object placement and refined overall display quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->